### PR TITLE
Add the possibility to reset the virtualizer player orientation

### DIFF
--- a/app/robots/iCubGenova04/oculusConfig.ini
+++ b/app/robots/iCubGenova04/oculusConfig.ini
@@ -4,7 +4,8 @@ name                    oculusRetargeting
 leftHandPosePort        /leftHandPose:o
 rightHandPosePort       /rightHandPose:o
 playerOrientationPort   /playerOrientation:i
-rpcPort_name            /rpc
+rpcWalkingPort_name     /WalkingRpc
+rpcVirtualizerPort_name /VirtualizerRpc
 
 [GENERAL]
 samplingTime            0.05

--- a/app/robots/iCubGenova04/oculusConfig.ini
+++ b/app/robots/iCubGenova04/oculusConfig.ini
@@ -4,8 +4,8 @@ name                    oculusRetargeting
 leftHandPosePort        /leftHandPose:o
 rightHandPosePort       /rightHandPose:o
 playerOrientationPort   /playerOrientation:i
-rpcWalkingPort_name     /WalkingRpc
-rpcVirtualizerPort_name /VirtualizerRpc
+rpcWalkingPort_name     /walkingRpc
+rpcVirtualizerPort_name /virtualizerRpc
 
 [GENERAL]
 samplingTime            0.05

--- a/app/robots/icubGazeboSim/oculusConfig.ini
+++ b/app/robots/icubGazeboSim/oculusConfig.ini
@@ -4,7 +4,8 @@ name                    oculusRetargeting
 leftHandPosePort        /leftHandPose:o
 rightHandPosePort       /rightHandPose:o
 playerOrientationPort   /playerOrientation:i
-rpcPort_name            /rpc
+rpcWalkingPort_name     /WalkingRpc
+rpcVirtualizerPort_name /VirtualizerRpc
 
 [GENERAL]
 samplingTime            0.05

--- a/app/robots/icubGazeboSim/oculusConfig.ini
+++ b/app/robots/icubGazeboSim/oculusConfig.ini
@@ -4,8 +4,8 @@ name                    oculusRetargeting
 leftHandPosePort        /leftHandPose:o
 rightHandPosePort       /rightHandPose:o
 playerOrientationPort   /playerOrientation:i
-rpcWalkingPort_name     /WalkingRpc
-rpcVirtualizerPort_name /VirtualizerRpc
+rpcWalkingPort_name     /walkingRpc
+rpcVirtualizerPort_name /virtualizerRpc
 
 [GENERAL]
 samplingTime            0.05

--- a/app/virtualizerRetargeting/virtualizerConfig.ini
+++ b/app/virtualizerRetargeting/virtualizerConfig.ini
@@ -7,4 +7,4 @@ deadzone        0.05
 # RPC options
 playerOrientationPort_name    /playerOrientation:o
 robotOrientationPort_name     /robotOrientation:i
-rpcWalkingPort_name           /WalkingRpc
+rpcWalkingPort_name           /walkingRpc

--- a/app/virtualizerRetargeting/virtualizerConfig.ini
+++ b/app/virtualizerRetargeting/virtualizerConfig.ini
@@ -7,4 +7,4 @@ deadzone        0.05
 # RPC options
 playerOrientationPort_name    /playerOrientation:o
 robotOrientationPort_name     /robotOrientation:i
-rpcPort_name                  /rpc:o 
+rpcWalkingPort_name           /WalkingRpc

--- a/app/virtualizerRetargeting/virtualizerConfig.ini
+++ b/app/virtualizerRetargeting/virtualizerConfig.ini
@@ -2,7 +2,8 @@ name            virtualizer
 period          0.05
 
 # Joypad options
-deadzone        0.05
+deadzone                0.05
+velocityScaling         2.0
 
 # RPC options
 playerOrientationPort_name    /playerOrientation:o

--- a/modules/Oculus_module/include/OculusModule.hpp
+++ b/modules/Oculus_module/include/OculusModule.hpp
@@ -100,8 +100,9 @@ private:
     /** Port used to retrieve the headset oculus orientation. */
     yarp::os::BufferedPort<yarp::os::Bottle> m_oculusOrientationPort;
 
-    yarp::os::RpcClient m_rpcClient; /**< Rpc client used for sending command to the walking
-                                        controller */
+    yarp::os::RpcClient m_rpcWalkingClient; /**< Rpc client used for sending command to the walking
+                                               controller */
+    yarp::os::RpcClient m_rpcVirtualizerClient; /**< Rpc client used for sending command to the virtualizer */
 
     double m_robotYaw; /**< Yaw angle of the robot base */
 

--- a/modules/Virtualizer_module/CMakeLists.txt
+++ b/modules/Virtualizer_module/CMakeLists.txt
@@ -38,7 +38,7 @@ set(${EXE_TARGET_NAME}_HDR
 
 # Thrift
 set(${EXE_TARGET_NAME}_THRIFT_HDR
-  thrift/ virtualizerCommand.thrift
+  thrift/virtualizerCommand.thrift
   )
 yarp_add_idl(${EXE_TARGET_NAME}_THRIFT_SRC ${${EXE_TARGET_NAME}_THRIFT_HDR})
 

--- a/modules/Virtualizer_module/include/VirtualizerModule.hpp
+++ b/modules/Virtualizer_module/include/VirtualizerModule.hpp
@@ -22,7 +22,7 @@
 #include "CVirt.h"
 #include "CVirtDevice.h"
 
-#include <thrifts/VirtualizerCommands.h>
+#include <thrift/VirtualizerCommands.h>
 
 /**
  * RFModule useful to handle the Virtualizere

--- a/modules/Virtualizer_module/include/VirtualizerModule.hpp
+++ b/modules/Virtualizer_module/include/VirtualizerModule.hpp
@@ -32,9 +32,10 @@ class VirtualizerModule : public yarp::os::RFModule,  public VirtualizerCommands
 private:
     double m_dT; /**< RFModule period. */
     double m_deadzone; /**< Value of the deadzone. */
-    double m_robotYaw;
-    double velocity_factor;
-    double oldPlayerYaw;
+    double m_robotYaw; /**<Robot orientation. */
+    double m_velocityScaling; /**< Linear velocity scaling factor   */
+    double m_oldPlayerYaw; /**< Player orientation (coming from the virtualizer) retrieved at the
+                              previous time step. */
 
     yarp::os::Port m_rpcServerPort; /**< Port used to send command to the virtualizer application. */
 

--- a/modules/Virtualizer_module/src/VirtualizerModule.cpp
+++ b/modules/Virtualizer_module/src/VirtualizerModule.cpp
@@ -33,9 +33,6 @@ bool VirtualizerModule::configureVirtualizer()
                 return false;
             }
 
-            // reset player orientation
-            m_cvirtDeviceID->ResetPlayerOrientation();
-
             return true;
         }
         // wait one millisecond
@@ -101,7 +98,7 @@ bool VirtualizerModule::configure(yarp::os::ResourceFinder& rf)
         return false;
     }
 
-    if (!YarpHelper::getStringFromSearchable(rf, "rpcPort_name", portName))
+    if (!YarpHelper::getStringFromSearchable(rf, "rpcWalkingPort_name", portName))
     {
         yError() << "[configure] Unable to get a string from a searchable";
         return false;
@@ -130,6 +127,9 @@ bool VirtualizerModule::configure(yarp::os::ResourceFinder& rf)
     // remove me!!!
     // this is because the virtualizer is not ready
     yarp::os::Time::delay(0.5);
+
+	// reset player orientation
+    m_cvirtDeviceID->ResetPlayerOrientation();
 
     // reset some quanties
     m_robotYaw = 0;
@@ -216,6 +216,11 @@ void VirtualizerModule::resetPlayerOrientation()
 {
     std::lock_guard<std::mutex> guard(m_mutex);
     m_cvirtDeviceID->ResetPlayerOrientation();
+
+    oldPlayerYaw = (double)(m_cvirtDeviceID->GetPlayerOrientation());
+    oldPlayerYaw *= 360.0f;
+    oldPlayerYaw = oldPlayerYaw * M_PI / 180;
+    oldPlayerYaw = Angles::normalizeAngle(oldPlayerYaw);
     return;
 }
 


### PR DESCRIPTION
This PR wants to implement the resetting feature for the player orientation coming from the virtualizer. 
In details:
1. it exposes the resetting feature through a YARP rpc port 
2. the orientation of the player is reset using the `ResetPlayerOrientation()` method implemented in the Cyberith SDK
3. The player orientation is reset by the Oculus application when the user starts the walking application

### TODO 
- [x] Test on iCub