### PR TITLE
Fix the head tracking 

### DIFF
--- a/modules/Oculus_module/src/HeadRetargeting.cpp
+++ b/modules/Oculus_module/src/HeadRetargeting.cpp
@@ -42,7 +42,7 @@ void HeadRetargeting::inverseKinematics(const iDynTree::Rotation& chest_R_head, 
     }
 
     // minus due to the joints structure of the iCub neck
-    neckPitch = -neckPitch;
+    neckRoll = -neckRoll;
     return;
 }
 
@@ -50,7 +50,7 @@ iDynTree::Rotation HeadRetargeting::forwardKinematics(const double& neckPitch, c
                                                       const double& neckYaw)
 {
     iDynTree::Rotation chest_R_head;
-    chest_R_head = iDynTree::Rotation::RotY(-neckPitch) * iDynTree::Rotation::RotX(neckRoll)
+    chest_R_head = iDynTree::Rotation::RotY(neckPitch) * iDynTree::Rotation::RotX(-neckRoll)
         * iDynTree::Rotation::RotZ(neckYaw);
 
     return chest_R_head;
@@ -111,8 +111,7 @@ void HeadRetargeting::setDesiredHeadOrientation(const yarp::sig::Matrix& oculusI
 
 bool HeadRetargeting::move()
 {
-     m_teleopFrame_R_headOculus = m_oculusInertial_R_teleopFrame.inverse()
-         * m_oculusInertial_R_headOculus;
+     m_teleopFrame_R_headOculus = m_oculusInertial_R_headOculus * m_oculusInertial_R_teleopFrame.inverse();
 //   m_desiredHeadOrientation = m_playerOrientation.inverse() * m_oculusRoot_T_oculusHeadset;
 
     // notice here the following assumption is done:

--- a/modules/Oculus_module/src/HeadRetargeting.cpp
+++ b/modules/Oculus_module/src/HeadRetargeting.cpp
@@ -16,7 +16,7 @@
 #include <Utils.hpp>
 
 // This code was taken from https://www.geometrictools.com/Documentation/EulerAngles.pdf
-// Section 2.2
+// Section 2.3
 void HeadRetargeting::inverseKinematics(const iDynTree::Rotation& chest_R_head, double& neckPitch,
                                         double& neckRoll, double& neckYaw)
 {
@@ -41,7 +41,7 @@ void HeadRetargeting::inverseKinematics(const iDynTree::Rotation& chest_R_head, 
         neckYaw = 0;
     }
 
-    // minus due to the joints structure of the iCub neck
+    // minus due to the joints mechanism of the iCub neck
     neckRoll = -neckRoll;
     return;
 }
@@ -121,6 +121,8 @@ bool HeadRetargeting::move()
     inverseKinematics(m_teleopFrame_R_headOculus, desiredNeckJoint(0),
                       desiredNeckJoint(1), desiredNeckJoint(2));
 
+    // Notice: this can generate problems when the inverse kinematics return angles
+    // near the singularity. it would be nice to implement a smoother in SO(3).
     m_headTrajectorySmoother->computeNextValues(desiredNeckJoint);
     m_desiredJointValue = m_headTrajectorySmoother->getPos();
 

--- a/modules/Oculus_module/src/HeadRetargeting.cpp
+++ b/modules/Oculus_module/src/HeadRetargeting.cpp
@@ -111,8 +111,7 @@ void HeadRetargeting::setDesiredHeadOrientation(const yarp::sig::Matrix& oculusI
 
 bool HeadRetargeting::move()
 {
-     m_teleopFrame_R_headOculus = m_oculusInertial_R_headOculus * m_oculusInertial_R_teleopFrame.inverse();
-//   m_desiredHeadOrientation = m_playerOrientation.inverse() * m_oculusRoot_T_oculusHeadset;
+    m_teleopFrame_R_headOculus = m_oculusInertial_R_teleopFrame.inverse() * m_oculusInertial_R_headOculus;
 
     // notice here the following assumption is done:
     // desiredNeckJoint(0) = neckPitch

--- a/modules/Oculus_module/src/OculusModule.cpp
+++ b/modules/Oculus_module/src/OculusModule.cpp
@@ -579,13 +579,13 @@ bool OculusModule::updateModule()
     neckRoll = neckEncoders(1);
     neckYaw = neckEncoders(2);
     iDynTree::Rotation root_R_head = HeadRetargeting::forwardKinematics(neckPitch, neckRoll, neckYaw);
-    iDynTree::Rotation inertial_R_root = iDynTree::Rotation::RotZ(m_robotYaw);
+    iDynTree::Rotation inertial_R_root = iDynTree::Rotation::RotZ(-m_playerOrientation);
 
     // inertial_R_head is used to simulate an imu required by the cam calibration application
     // Since the imu mounted on the head of the robot has the x axis pointing backwatd  the
     // RotZ(180) is added
-    iDynTree::Rotation inertial_R_head = iDynTree::Rotation::RotZ(iDynTree::deg2rad(180))
-        * inertial_R_root * root_R_head;
+    // iDynTree::Rotation inertial_R_head = iDynTree::Rotation::RotZ(iDynTree::deg2rad(180))
+    iDynTree::Rotation inertial_R_head = inertial_R_root * root_R_head;
     iDynTree::Vector3 inertial_R_headRPY = inertial_R_head.asRPY();
 
     // todo check the minus

--- a/modules/Oculus_module/src/OculusModule.cpp
+++ b/modules/Oculus_module/src/OculusModule.cpp
@@ -382,6 +382,8 @@ bool OculusModule::getTransforms()
                 desiredHeadOrientationVector(i)
                     = iDynTree::deg2rad(desiredHeadOrientation->get(i).asDouble());
 
+            // Notice that the data coming from the port are written in the following order:
+            // [ pitch, -roll, yaw].
             iDynTree::toEigen(m_oculusRoot_T_headOculus).block(0, 0, 3, 3)
               = iDynTree::toEigen(iDynTree::Rotation::RPY(-desiredHeadOrientationVector(1),
                                                           desiredHeadOrientationVector(0),
@@ -585,13 +587,9 @@ bool OculusModule::updateModule()
     iDynTree::Rotation inertial_R_root = iDynTree::Rotation::RotZ(-m_playerOrientation);
 
     // inertial_R_head is used to simulate an imu required by the cam calibration application
-    // Since the imu mounted on the head of the robot has the x axis pointing backwatd  the
-    // RotZ(180) is added
-    // iDynTree::Rotation inertial_R_head = iDynTree::Rotation::RotZ(iDynTree::deg2rad(180))
     iDynTree::Rotation inertial_R_head = inertial_R_root * root_R_head;
     iDynTree::Vector3 inertial_R_headRPY = inertial_R_head.asRPY();
 
-    // todo check the minus
     imagesOrientation.addDouble(iDynTree::rad2deg(inertial_R_headRPY(0)));
     imagesOrientation.addDouble(iDynTree::rad2deg(inertial_R_headRPY(1)));
     imagesOrientation.addDouble(iDynTree::rad2deg(inertial_R_headRPY(2)));

--- a/modules/Oculus_module/src/OculusModule.cpp
+++ b/modules/Oculus_module/src/OculusModule.cpp
@@ -20,6 +20,7 @@
 #include <OculusModule.hpp>
 #include <Utils.hpp>
 
+
 bool OculusModule::configureTranformClient(const yarp::os::Searchable& config)
 {
     yarp::os::Property options;
@@ -372,7 +373,8 @@ bool OculusModule::getTransforms()
     {
         // head
         yarp::os::Bottle* desiredHeadOrientation = NULL;
-        iDynTree::Vector3 desiredHeadOrientationVector;
+
+        iDynTree::Vector3  desiredHeadOrientationVector;
         desiredHeadOrientation = m_oculusOrientationPort.read(false);
         if (desiredHeadOrientation != NULL)
         {
@@ -381,9 +383,9 @@ bool OculusModule::getTransforms()
                     = iDynTree::deg2rad(desiredHeadOrientation->get(i).asDouble());
 
             iDynTree::toEigen(m_oculusRoot_T_headOculus).block(0, 0, 3, 3)
-                = iDynTree::toEigen(HeadRetargeting::forwardKinematics(desiredHeadOrientationVector(0),
-                                                                       desiredHeadOrientationVector(1),
-                                                                       desiredHeadOrientationVector(2)));
+              = iDynTree::toEigen(iDynTree::Rotation::RPY(-desiredHeadOrientationVector(1),
+                                                          desiredHeadOrientationVector(0),
+                                                          desiredHeadOrientationVector(2)));
         }
     } else
     {
@@ -470,6 +472,7 @@ bool OculusModule::updateModule()
 
         m_head->setPlayerOrientation(m_playerOrientation);
         m_head->setDesiredHeadOrientation(m_oculusRoot_T_headOculus);
+        // m_head->setDesiredHeadOrientation(desiredHeadOrientationVector(0), desiredHeadOrientationVector(1), desiredHeadOrientationVector(2));
         if (!m_head->move())
         {
             yError() << "[updateModule::updateModule] unable to move the head";
@@ -566,8 +569,8 @@ bool OculusModule::updateModule()
             // TODO add a visual feedback for the user
             cmd.addString("startWalking");
             m_rpcWalkingClient.write(cmd, outcome);
-            if(outcome.get(0).asBool())
-                m_state = OculusFSM::Running;
+            // if(outcome.get(0).asBool())
+            m_state = OculusFSM::Running;
         }
     }
     yarp::os::Bottle& imagesOrientation = m_imagesOrientationPort.prepare();


### PR DESCRIPTION
- revert the sign in the head inverse kinematics
- fix coupling between virtualizer and Oculus headset in the head retargeting
- fix fake imu signal

This issue wants to be a workaround for https://github.com/dic-iit/element_retargeting-from-human/issues/80.

The PR was successfully tested on the robot, 

cc @S-dafarra @kouroshD 