### PR TITLE
Update the application to restore compatibility with the latest version of the walking

### DIFF
--- a/app/scripts/dcmWalkingRetargeting.xml
+++ b/app/scripts/dcmWalkingRetargeting.xml
@@ -49,6 +49,7 @@
   <module>
     <name>WalkingModule</name>
     <node>icub-head</node>
+    <parameters> --from dcm_walking_retargeting.ini </parameters>
   </module>
 
   <module>

--- a/app/scripts/dcmWalkingRetargetingVirtualizer.xml
+++ b/app/scripts/dcmWalkingRetargetingVirtualizer.xml
@@ -47,6 +47,7 @@
   <module>
     <name>WalkingModule</name>
     <node>icub-head</node>
+    <parameters> --from dcm_walking_retargeting.ini </parameters>
   </module>
 
   <module>


### PR DESCRIPTION
This PR allows running the [latest version](https://github.com/robotology/walking-controllers/commit/749b8f5623e8803047aea263629cbbb2f4fe4b18) of the walking-controller from `yarpmanager`.