### PR TITLE
Fix the bug related to the Scope of using Xsens in config file

### DIFF
--- a/app/robots/iCubGazeboV2_5/XsensRetargeting.ini
+++ b/app/robots/iCubGazeboV2_5/XsensRetargeting.ini
@@ -19,6 +19,6 @@ human_joint_list_stream  ("neck_roll",       "l_elbow",          "l_shoulder_rol
 
 smoothingTime   0.25
 # The max difference (threshold) of a joint value coming from the human (rad)
-jointDifferenceThreshold 1.5
+jointDifferenceThreshold 0.5
 wholeBodyJointsPort           /HumanStateWrapper/state:i
 controllerPort     /jointPosition:o

--- a/app/robots/icubGazeboSim/XsensRetargeting.ini
+++ b/app/robots/icubGazeboSim/XsensRetargeting.ini
@@ -19,6 +19,6 @@ human_joint_list_stream  ("neck_roll",       "l_elbow",          "l_shoulder_rol
 
 smoothingTime   0.25
 # The max difference (threshold) of a joint value coming from the human (rad)
-jointDifferenceThreshold 1.5
+jointDifferenceThreshold 0.5
 wholeBodyJointsPort           /HumanStateWrapper/state:i
 controllerPort     /jointPosition:o

--- a/app/robots/icubGazeboSim/oculusConfig.ini
+++ b/app/robots/icubGazeboSim/oculusConfig.ini
@@ -8,8 +8,9 @@ rpcWalkingPort_name     /walkingRpc
 rpcVirtualizerPort_name /virtualizerRpc
 
 [GENERAL]
-samplingTime            0.05
+samplingTime            0.01
 robot                   icubSim
+useXsens                1
 
 # include hand parameters
 [include HEAD_RETARGETING "headRetargetingParams.ini"]
@@ -21,6 +22,9 @@ robot                   icubSim
 # include hand parameters
 [include LEFT_HAND_RETARGETING "leftHandRetargetingParams.ini"]
 [include RIGHT_HAND_RETARGETING "rightHandRetargetingParams.ini"]
+
+# include Torso parameters [iff using Xsens]
+[include TORSO_RETARGETING "torsoRetargeting.ini"]
 
 [OCULUS]
 root_frame_name                 mobile_base_body_link

--- a/app/robots/icubGazeboSim/rightFingersRetargetingParams.ini
+++ b/app/robots/icubGazeboSim/rightFingersRetargetingParams.ini
@@ -1,6 +1,6 @@
 remote_control_boards   ("right_arm")
 joints_list             ("r_thumb_proximal", "r_thumb_distal", "r_index_proximal", "r_index-distal", "r_middle-proximal", "r_middle-distal", "r_pinky")
 
-useVelocity           0
+useVelocity           1
 
 fingersScaling        (1, 3.5, 2, 3.5, 1, 3.5, 5)

--- a/app/robots/icubGazeboSim/torsoRetargeting.ini
+++ b/app/robots/icubGazeboSim/torsoRetargeting.ini
@@ -1,0 +1,2 @@
+remote_control_boards   ("torso")
+joints_list             ("torso_pitch", "torso_roll", "torso_yaw")

--- a/app/scripts/dcmWalkingRetargeting.xml
+++ b/app/scripts/dcmWalkingRetargeting.xml
@@ -59,7 +59,7 @@
       <port timeout="5.0">/transformServer/transforms:o</port>
       <port timeout="5.0">/joypadDevice/Oculus/rpc:i</port>
     </dependencies>
-    <parameters> --useXsens 0 </parameters>
+    <parameters> --GENERAL::useXsens 0 </parameters>
   </module>
 
   <!-- Connections -->

--- a/app/scripts/dcmWalkingRetargetingVirtualizer.xml
+++ b/app/scripts/dcmWalkingRetargetingVirtualizer.xml
@@ -59,7 +59,7 @@
   <module>
     <name>OculusRetargetingModule</name>
     <node>icub-head</node>
-    <parameters> --OCULUS::move_icub_using_joypad 0 --useXsens 0</parameters>
+    <parameters> --OCULUS::move_icub_using_joypad 0 --GENERAL::useXsens 0</parameters>
     <dependencies>
       <port timeout="5.0">/transformServer/transforms:o</port>
       <port timeout="5.0">/joypadDevice/Oculus/rpc:i</port>


### PR DESCRIPTION
With this PR we fix the bug related to using xsens option:
During preperation for [ dott. Paolucci demo ](https://github.com/dic-iit/lab-events-demos/issues/112) , we had the problem to use `devel` branch of `walking-teleoperation` to perform walking-Oculus teleoperation (without using Xsens) sceanrio.
The problem was, when we were starting the teleoperaion `startWalking`, the robot hand were going smoothly toward zero.
Investaging on the problem, I understood the problem was from the way I was passing the parameters to `oculusModule`. `useXsens` parameter is defined under the `GENERAL` scope in config files, however, when passing the parameters, I was not identifying `GENERAL`. Therefore, the configuration was not correctly performed, and during the execeution in `oculusModule` the option `useXsens` was `true`.
Additionally, when investigating on this problem, we understood, the ports `/oculusRetargeting/rightHandPose:o` and `/oculusRetargeting/leftHandPose:o` are empty correctly, i.e., nothing written in these port. However, in the controller, it goes toward joint values of `0`. We should investigate more on the walking-controller side and try to fix this problem.

@fjandrad @DanielePucci 
