### PR TITLE
Add Negative velocity, Add in-point robot rotation

### DIFF
--- a/app/virtualizerRetargeting/virtualizerConfig.ini
+++ b/app/virtualizerRetargeting/virtualizerConfig.ini
@@ -2,10 +2,11 @@ name            virtualizer
 period          0.05
 
 # Joypad options
-deadzone                0.05
-velocityScaling         2.0
+deadzone        0.20
 
 # RPC options
 playerOrientationPort_name    /playerOrientation:o
 robotOrientationPort_name     /robotOrientation:i
 rpcWalkingPort_name           /walkingRpc
+scale_X                       2.0
+scale_Y                       1.0

--- a/modules/Virtualizer_module/include/VirtualizerModule.hpp
+++ b/modules/Virtualizer_module/include/VirtualizerModule.hpp
@@ -32,10 +32,10 @@ class VirtualizerModule : public yarp::os::RFModule, public VirtualizerCommands
 private:
     double m_dT; /**< RFModule period. */
     double m_deadzone; /**< Value of the deadzone. */
-    double m_robotYaw; /**<Robot orientation. */
-    double m_velocityScaling; /**< Linear velocity scaling factor   */
-    double m_oldPlayerYaw; /**< Player orientation (coming from the virtualizer) retrieved at the
-                              previous time step. */
+    double m_robotYaw;
+    //    double velocity_factor;
+    double m_scale_X, m_scale_Y;
+    double oldPlayerYaw;
 
     yarp::os::Port
         m_rpcServerPort; /**< Port used to send command to the virtualizer application. */


### PR DESCRIPTION
With this PR, I respond to the feature we were seeking to enable the virtualizer teleoperation scenario have negative velocity, and also enable the robot rotate in-place.

However, with in-place rotation feature, the problem of [issue#81](https://github.com/dic-iit/element_retargeting-from-human/issues/81) is more visible.

@DanielePucci @fjandrad 
