### PR TITLE
get the human joint list online, update the application files for Xse…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ build/
 
 TAGS
 compile_commands.json
+CMakeLists.txt.user

--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ Software related to walking and teleoperation.
 The suite includes:
 
 * **Oculus_module**: this is the module that implements retargeting of the upper body end_effectors.
-* **Virtualizer_module**: this module allows using the cyberith virtualizer as a joypad interface for walking commands.
-* **Utils_module**: an module that can be useful to implement some common functionality
+* **Virtualizer_module**: this module allows using the Cyberith virtualizer as a joypad interface for walking commands.
+* **Utils_module**: a module that can be useful to implement some common functionality
+* **Xsens_module**: a module that gets joint values from [human state provider](https://github.com/robotology/human-dynamics-estimation/) and maps them to the [walking controller](https://github.com/robotology/walking-controllers) input
 
 The technical description of the suit is described [here](./docs/FrameDescriptions.md).
 
@@ -16,21 +17,23 @@ The technical description of the suit is described [here](./docs/FrameDescriptio
  - [:running: Using the software with iCub](#running-using-the-software-with-iCub)
 
 # :orange_book: The general idea
-This software allows teleoperation of a walking humanoid robot with a walking controller that expects positions on the plane as walking direction commands for the planner.
+This software allows teleoperation of a biped humanoid robot,e.g., iCub, with a walking controller that expects speed and orientation of the robot locomotion on a horizontal plane and commands for upper body control of the humanoid robot.
 It implements the following architecture:
-* Oculus module that captures the end effectors of the hands and head of the human operator and commands the respective movement;
-* Virtualizer module [Optional] that graps the human walking teleoperation commands (orientation and Speed).
-
+* Oculus module: that captures the end effectors of the hands and head of the human operator and commands the respective movement (if only using Oculus VR);
+* Virtualizer module: [Optional]  grasps the human walking teleoperation commands (orientation and Speed).
+* Xsens module: [optional] maps the robot's joints values to the controller
 
 # :page_facing_up: Dependencies
 The description of dependencies are located [here](./docs/Dependencies.md).
 
 This guide is only for teleoperation dependencies on a Windows machine and it includes the guide to install Oculus module and Virtualizer module SDKs.
 
-Besides, you need to have a linux machine for **Walking-controllers** module described [here](https://github.com/robotology/walking-controllers/tree/devel_hand_retargeting).
+If you want to run the teleoperation scenario with Xsens MVN technologies, you need to enable the option [human-dynamics in robotology/superbuild](https://github.com/robotology/robotology-superbuild#human-dynamics) and install all the dependencies described there.
+
+Besides, you need to have a Linux machine for **Walking-controllers** module described [here](https://github.com/robotology/walking-controllers/tree/devel_hand_retargeting).
 
 # :hammer: Build the suite
-## Linux/macOs
+## Linux/macOS
 
 ```sh
 git clone https://github.com/robotology/walking-teleoperation.git
@@ -45,21 +48,22 @@ Follow the same instructions from the Powershell. One can also opt to use the ``
 
 # :running: Using the software with iCub
 Import the `DCM_WALKING_COORDINATOR_+_RETARGETING` to the `yarpmanager` applications.
-The current set-up allows to run the module either on windows, or from a linux machine through `yarprun --server /name_of_server`. The preference is the following.
-* Turn on the robot, through the linux machine.
+The current set-up allows running the module either on windows or from a Linux machine through `yarprun --server /name_of_server`. The preference is the following.
+* Turn on the robot, through the Linux machine.
 * On the windows machine, use the same network.
 * Do a `yarp namespace /the_robot_network_namespace`
 * Do a `yarprun --server /icub-virtualizer`
 * Calibrate the virtualizer and the oculus
 * At this point, the operator should be in the virtualizer wearing the oculus and in the zero configuration, i.e. zero orientation in the virtualizer, facing the same direction as the robot and standing still.
-* On the linux server, and from the `yarpmanager` run the application `DCM_WALKING_COORDINATOR_+_RETARGETING`
+* On the Linux server, and from the `yarpmanager` run one of the applications `DCM_walking_retargeting`,`DCM_walking_retargeting (Virtualizer)` ,`DCM_walking_retargeting_(Xsens)`, or `DCM_walking_retargeting_(Virtualizer_Xsens)` depending on the experiment you want to perform.
 * On the same application window, connect all the ports.
 * On the windows machine, adjust the image size and positioning (field of view) of the Oculus (to zoom out press ctrl+z, to move the right display use right ctrl+direction, to move the left display use left ctrl+direction ).
-* On the linux machine to adjust the image quality, use the `frameGrapperGui` in the `calib_cams` application.
+* On the Linux machine to adjust the image quality, use the `frameGrapperGui` in the `calib_cams` application.
+
 
 ## :warning: Warning
-Currently the supported robots are only:
+Currently, the supported robots are only:
 - ``iCubGenova04``
 - ``iCubGenova02``
 
-
+**To get the updated information about the dependencies branches and how to run, please check the wiki page of this repository.**

--- a/app/robots/iCubGazeboV2_5/XsensRetargeting.ini
+++ b/app/robots/iCubGazeboV2_5/XsensRetargeting.ini
@@ -3,19 +3,12 @@ samplingTime            0.01
 robot                   icub
 
 remote_control_boards   ("head", "torso", "left_arm", "right_arm")
-# Notice the order of the joint list is not wrong.
+# ROBOT JOINT LIST (Notice the order of the joint list is not wrong)
 # Indeed they are written according to the joint order of the walking-coordinator
 joints_list             ("neck_pitch", "neck_roll", "neck_yaw",
                          "torso_pitch", "torso_roll", "torso_yaw",
                          "l_shoulder_pitch", "l_shoulder_roll", "l_shoulder_yaw", "l_elbow", "l_wrist_prosup", "l_wrist_pitch", "l_wrist_yaw",
                          "r_shoulder_pitch", "r_shoulder_roll", "r_shoulder_yaw", "r_elbow",  "r_wrist_prosup", "r_wrist_pitch", "r_wrist_yaw")
-
-# Notice the order of the human joint list is not wrong.
-# Indeed they are written according to the human joint order of the HDE/HumanStateWrapper
-human_joint_list_stream  ("neck_roll",       "l_elbow",          "l_shoulder_roll",    "r_shoulder_yaw", "r_hip_yaw",  "r_shoulder_pitch", "torso_roll",    "l_ankle_roll",
-                          "l_shoulder_yaw",  "r_ankle_roll",     "torso_pitch",        "l_knee",         "r_elbow",    "l_hip_yaw",        "neck_yaw",      "r_wrist_prosup",
-                          "r_wrist_yaw",     "r_shoulder_roll",  "l_shoulder_pitch",   "l_hip_roll",     "neck_pitch",  "r_ankle_pitch",   "l_wrist_prosup", "l_ankle_pitch",
-                          "r_wrist_pitch",   "r_hip_pitch",      "r_knee",             "l_hip_pitch",    "l_wrist_yaw", "r_hip_roll",      "l_wrist_pitch",  "torso_yaw")
 
 smoothingTime   0.25
 # The max difference (threshold) of a joint value coming from the human (rad)

--- a/app/robots/iCubGenova04/XsensRetargeting.ini
+++ b/app/robots/iCubGenova04/XsensRetargeting.ini
@@ -3,19 +3,12 @@ samplingTime            0.01
 robot                   icub
 
 remote_control_boards   ("head", "torso", "left_arm", "right_arm")
-# Notice the order of the joint list is not wrong.
+# ROBOT JOINT LIST (Notice the order of the joint list is not wrong)
 # Indeed they are written according to the joint order of the walking-coordinator
 joints_list             ("neck_pitch", "neck_roll", "neck_yaw",
                          "torso_pitch", "torso_roll", "torso_yaw",
                          "l_shoulder_pitch", "l_shoulder_roll", "l_shoulder_yaw", "l_elbow", "l_wrist_prosup", "l_wrist_pitch", "l_wrist_yaw",
                          "r_shoulder_pitch", "r_shoulder_roll", "r_shoulder_yaw", "r_elbow",  "r_wrist_prosup", "r_wrist_pitch", "r_wrist_yaw")
-
-# Notice the order of the human joint list is not wrong.
-# Indeed they are written according to the human joint order of the HDE/HumanStateWrapper
-human_joint_list_stream  ("neck_roll",       "l_elbow",          "l_shoulder_roll",    "r_shoulder_yaw", "r_hip_yaw",  "r_shoulder_pitch", "torso_roll",    "l_ankle_roll",
-                          "l_shoulder_yaw",  "r_ankle_roll",     "torso_pitch",        "l_knee",         "r_elbow",    "l_hip_yaw",        "neck_yaw",      "r_wrist_prosup",
-                          "r_wrist_yaw",     "r_shoulder_roll",  "l_shoulder_pitch",   "l_hip_roll",     "neck_pitch",  "r_ankle_pitch",   "l_wrist_prosup", "l_ankle_pitch",
-                          "r_wrist_pitch",   "r_hip_pitch",      "r_knee",             "l_hip_pitch",    "l_wrist_yaw", "r_hip_roll",      "l_wrist_pitch",  "torso_yaw")
 
 smoothingTime   0.25
 # The max difference (threshold) of a joint value coming from the human (rad)

--- a/app/robots/icubGazeboSim/XsensRetargeting.ini
+++ b/app/robots/icubGazeboSim/XsensRetargeting.ini
@@ -3,19 +3,12 @@ samplingTime            0.01
 robot                   icubSim
 
 remote_control_boards   ("head", "torso", "left_arm", "right_arm")
-# Notice the order of the joint list is not wrong.
+# ROBOT JOINT LIST (Notice the order of the joint list is not wrong)
 # Indeed they are written according to the joint order of the walking-coordinator
 joints_list             ("neck_pitch", "neck_roll", "neck_yaw",
                          "torso_pitch", "torso_roll", "torso_yaw",
                          "l_shoulder_pitch", "l_shoulder_roll", "l_shoulder_yaw", "l_elbow", "l_wrist_prosup", "l_wrist_pitch", "l_wrist_yaw",
                          "r_shoulder_pitch", "r_shoulder_roll", "r_shoulder_yaw", "r_elbow",  "r_wrist_prosup", "r_wrist_pitch", "r_wrist_yaw")
-
-# Notice the order of the human joint list is not wrong.
-# Indeed they are written according to the human joint order of the HDE/HumanStateWrapper
-human_joint_list_stream  ("neck_roll",       "l_elbow",          "l_shoulder_roll",    "r_shoulder_yaw", "r_hip_yaw",  "r_shoulder_pitch", "torso_roll",    "l_ankle_roll",
-                          "l_shoulder_yaw",  "r_ankle_roll",     "torso_pitch",        "l_knee",         "r_elbow",    "l_hip_yaw",        "neck_yaw",      "r_wrist_prosup",
-                          "r_wrist_yaw",     "r_shoulder_roll",  "l_shoulder_pitch",   "l_hip_roll",     "neck_pitch",  "r_ankle_pitch",   "l_wrist_prosup", "l_ankle_pitch",
-                          "r_wrist_pitch",   "r_hip_pitch",      "r_knee",             "l_hip_pitch",    "l_wrist_yaw", "r_hip_roll",      "l_wrist_pitch",  "torso_yaw")
 
 smoothingTime   0.25
 # The max difference (threshold) of a joint value coming from the human (rad)

--- a/app/scripts/dcmWalkingRetargetingVirtualizerXsens.xml
+++ b/app/scripts/dcmWalkingRetargetingVirtualizerXsens.xml
@@ -43,6 +43,17 @@
     <node>icub-virtualizer</node>
   </module>
 
+  <module>
+    <name>yarprobotinterface</name>
+    <parameters>--config TransformServer.xml</parameters>
+    <node>icub30</node>
+  </module>
+
+  <module>
+    <name>yarprobotinterface</name>
+    <parameters>--config RobotStateProvider_iCub.xml</parameters>
+    <node>icub30</node>
+  </module>
 
   <!-- Modules -->
   <module>
@@ -158,7 +169,7 @@
   </connection>
 
   <connection>
-    <from>/HDE/RobotStateWrapper/state:o</from>
+    <from>/iCub/RobotStateWrapper/state:o</from>
     <to>/XsensRetargeting/HumanStateWrapper/state:i</to>
   </connection>
 

--- a/app/scripts/dcmWalkingRetargetingXsens.xml
+++ b/app/scripts/dcmWalkingRetargetingXsens.xml
@@ -45,6 +45,19 @@
     <node>icub-virtualizer</node>
   </module>
 
+  <module>
+    <name>yarprobotinterface</name>
+    <parameters>--config TransformServer.xml</parameters>
+    <node>icub30</node>
+  </module>
+
+  <module>
+    <name>yarprobotinterface</name>
+    <parameters>--config RobotStateProvider_iCub.xml</parameters>
+    <node>icub30</node>
+  </module>
+
+
 
   <!-- Modules -->
   <module>
@@ -113,7 +126,7 @@
 
 
   <connection>
-    <from>/HDE/RobotStateWrapper/state:o</from>
+    <from>/iCub/RobotStateWrapper/state:o</from>
     <to>/XsensRetargeting/HumanStateWrapper/state:i</to>
   </connection>
 

--- a/docs/Dependencies.md
+++ b/docs/Dependencies.md
@@ -28,20 +28,32 @@
       
       - Add the following variables value in robotology/yarp using CMake GUI (search for glew!)
         ```
-        GLEW_INCLUDE_DIR: <path to codes workspace>/glew/glew-2.1.0/glew-2.1.0/include
+        GLEW_INCLUDE_DIR: <path to codes workspace>/glew/glew-2.1.0/include
                (inside this folder you should find the GL folder and inside that the header files)
           
-        GLEW_LIBRARY_DEBUG: <path to codes workspace>/glew/glew-2.1.0/glew-2.1.0/lib/Debug/x64/glew32d.lib
+        GLEW_SHARED_LIBRARY_DEBUG:   <path to codes workspace>/glew/glew-2.1.0/lib/Debug/x64/glew32d.lib
               
-        GLEW_LIBRARY_RELEASE: <path to codes workspace>/glew/glew-2.1.0/glew-2.1.0/lib/Release/x64/glew32.lib
+        GLEW_SHARED_LIBRARY_RELEASE: <path to codes workspace>/glew/glew-2.1.0/lib/Release/x64/glew32.lib
+        
+        GLEW_STATIC_LIBRARY_DEBUG:   <path to codes workspace>/glew/glew-2.1.0/lib/Debug/x64/glew32sd.lib
+              
+        GLEW_STATIC_LIBRARY_RELEASE: <path to codes workspace>/glew/glew-2.1.0/lib/Release/x64/glew32s.lib
               
         YARP_USE_GLEW: check the box
         ```
-      - Append the following directories to the `Path` User environmental variable, for example using the [Rapid Environment Editor](https://www.rapidee.com):
+      - Append the following directories to the User environmental variable, for example using the [Rapid Environment Editor](https://www.rapidee.com):
         ```
         Path: (Expandable string)
-                    <path to codes workspace>\glew\glew-2.1.0\glew-2.1.0\bin\Release\x64
-                    <path to codes workspace>\glew\glew-2.1.0\glew-2.1.0\bin\Debug\x64
+                    <path to codes workspace>\glew\glew-2.1.0\bin\Release\x64
+                    <path to codes workspace>\glew\glew-2.1.0\bin\Debug\x64
+                    <path to codes workspace>\glew\glew-2.1.0\lib\Release
+                    
+        CMAKE_PREFIX_PATH: (Expandable string)
+                    <path to codes workspace>\glew\glew-2.1.0\include
+                    <path to codes workspace>\glew\glew-2.1.0\lib
+
+        GLEW_DIR: (Expandable string)
+                    <path to codes workspace>\glew\glew-2.1.0\
         ```  
   
       - Don't forget to configure, generate the cmake (cmake gui --> robotology yarp) and build release mode the yarp using vs15.  
@@ -63,7 +75,7 @@
       
       - Add the following value to the `CMAKE_INSTALL_PREFIX` of the glfw project
       ```
-      CMAKE_INSTALL_PREFIX: <path to codes workspace>/glfw/glfw-3.2.1/glfw-3.2.1/build/install
+      CMAKE_INSTALL_PREFIX: <path to codes workspace>/glfw/glfw-3.2.1/build/install
       ```
       - After builing the project, install it as well.
 
@@ -89,7 +101,7 @@
       - if you have problems with compiling GLFW3, [this link](https://www.glfw.org/docs/latest/compile_guide.html#compile_generate) or [here](https://github.com/nigels-com/glew) may help.
           
           
-    4. `LibOVR`: to dowload the SDK, you can go to [this website](https://developer.oculus.com/downloads/), choose "Native Windows", then "Core Package: OCULUS SDK for windows". Select the version 1.16.0 to download. Or easily follow this [link](https://developer.oculus.com/downloads/package/oculus-sdk-for-windows/1.16.0/) and choose version 1.16.0 to download.
+    4. `LibOVR`: to dowload the SDK, you can go to [this website](https://developer.oculus.com/downloads/), choose "Native Windows", then "Core Package: OCULUS SDK for windows". Select the version 1.40.0 to download. Or easily follow this [link](https://developer.oculus.com/downloads/package/oculus-sdk-for-windows/1.40.0/) and choose version 1.40.0 to download.
     
       - Extract and place the package in your workspace (in our case in same path of robotology-superbuild), inside that there are two libraries which we need: LibOVR, and LibOVRKernel.
       

--- a/modules/Xsens_module/include/XsensRetargeting.hpp
+++ b/modules/Xsens_module/include/XsensRetargeting.hpp
@@ -35,6 +35,8 @@ public:
 class XsensRetargeting : public yarp::os::RFModule
 {
 private:
+    class impl;
+    std::unique_ptr<impl> pImpl;
     /** Minimum jerk trajectory smoother for the desired whole body joints */
     std::unique_ptr<iCub::ctrl::minJerkTrajGen> m_WBTrajectorySmoother{nullptr};
     yarp::sig::Vector m_jointValues, m_smoothedJointValues;

--- a/modules/Xsens_module/include/XsensRetargeting.hpp
+++ b/modules/Xsens_module/include/XsensRetargeting.hpp
@@ -35,6 +35,7 @@ public:
 class XsensRetargeting : public yarp::os::RFModule
 {
 private:
+    /** An implementation class for spepcific functionalities required in this module. */
     class impl;
     std::unique_ptr<impl> pImpl;
     /** Minimum jerk trajectory smoother for the desired whole body joints */

--- a/modules/Xsens_module/src/XsensRetargeting.cpp
+++ b/modules/Xsens_module/src/XsensRetargeting.cpp
@@ -6,7 +6,15 @@
 class XsensRetargeting::impl
 {
 public:
-    bool mapJointsHDE2CONTROLLER(std::vector<std::string> robotJointsListNames,
+    /*
+     * map the joint values (order) coming from HDE to the controller order
+     * @param robotJointsListNames list of the joint names used in controller
+     * @param humanJointsListName list of the joint names received from the HDE
+     * (human-dynamics-estimation repository)
+     * @param humanToRobotMap the container for mapping of the human joints to the robot ones
+     * @return true in case of success and false otherwise
+     */
+    bool mapJointsHDE2Controller(std::vector<std::string> robotJointsListNames,
                                  std::vector<std::string> humanJointsListName,
                                  std::vector<unsigned>& humanToRobotMap);
 };
@@ -187,7 +195,7 @@ bool XsensRetargeting::getJointValues()
             }
         }
         /* find the map between the human and robot joint list orders*/
-        if (!pImpl->mapJointsHDE2CONTROLLER(
+        if (!pImpl->mapJointsHDE2Controller(
                 m_robotJointsListNames, m_humanJointsListName, m_humanToRobotMap))
         {
             yError() << "[XsensRetargeting::getJointValues()] mapping is not possible";
@@ -254,7 +262,7 @@ bool XsensRetargeting::close()
 {
     return true;
 }
-bool XsensRetargeting::impl::mapJointsHDE2CONTROLLER(std::vector<std::string> robotJointsListNames,
+bool XsensRetargeting::impl::mapJointsHDE2Controller(std::vector<std::string> robotJointsListNames,
                                                      std::vector<std::string> humanJointsListName,
                                                      std::vector<unsigned>& humanToRobotMap)
 {

--- a/modules/Xsens_module/src/XsensRetargeting.cpp
+++ b/modules/Xsens_module/src/XsensRetargeting.cpp
@@ -3,7 +3,16 @@
 #include <iterator>
 #include <sstream>
 
-XsensRetargeting::XsensRetargeting(){};
+class XsensRetargeting::impl
+{
+public:
+    bool mapJointsHDE2CONTROLLER(std::vector<std::string> robotJointsListNames,
+                                 std::vector<std::string> humanJointsListName,
+                                 std::vector<unsigned>& humanToRobotMap);
+};
+
+XsensRetargeting::XsensRetargeting()
+    : pImpl{new impl()} {};
 
 XsensRetargeting::~XsensRetargeting(){};
 
@@ -63,36 +72,6 @@ bool XsensRetargeting::configure(yarp::os::ResourceFinder& rf)
     yInfo() << "XsensRetargeting::configure:  smoothingTime: " << smoothingTime;
     yInfo() << "XsensRetargeting::configure:  NoOfJoints: " << m_actuatedDOFs;
 
-    // check the human joints name list
-    yarp::os::Value* humanAxesListYarp;
-    if (!rf.check("human_joint_list_stream", humanAxesListYarp))
-    {
-        yError() << "[XsensRetargeting::configure] Unable to find human_joint_list_stream into "
-                    "config file.";
-        return false;
-    }
-
-    if (!YarpHelper::yarpListToStringVector(humanAxesListYarp, m_humanJointsListName))
-    {
-        yError() << "[XsensRetargeting::configure] Unable to convert yarp list into a "
-                    "vector of strings.";
-        return false;
-    }
-
-    yInfo() << "Human joints name list: [human joints list] [robot joints list]"
-            << m_humanJointsListName.size() << " , " << m_robotJointsListNames.size();
-
-    for (size_t i = 0; i < m_humanJointsListName.size(); i++)
-    {
-        if (i < m_robotJointsListNames.size())
-            yInfo() << "(" << i << "): " << m_humanJointsListName[i] << " , "
-                    << m_robotJointsListNames[i];
-        else
-        {
-            yInfo() << "(" << i << "): " << m_humanJointsListName[i] << " , --";
-        }
-    }
-
     std::string portName;
     if (!YarpHelper::getStringFromSearchable(rf, "wholeBodyJointsPort", portName))
     {
@@ -114,37 +93,6 @@ bool XsensRetargeting::configure(yarp::os::ResourceFinder& rf)
     {
         yError() << "[XsensRetargeting::configure] Unable to open the port " << portName;
         return false;
-    }
-
-    // I should do a maping between two vectors here.
-
-    bool foundMatch = false;
-    for (unsigned i = 0; i < m_robotJointsListNames.size(); i++)
-    {
-        for (unsigned j = 0; j < m_humanJointsListName.size(); j++)
-        {
-
-            if (m_robotJointsListNames[i] == m_humanJointsListName[j])
-            {
-                foundMatch = true;
-                m_humanToRobotMap.push_back(j);
-                break;
-            }
-        }
-        if (!foundMatch)
-        {
-            yError() << "not found match for: " << m_robotJointsListNames[i] << " , " << i;
-            ;
-            return false;
-        }
-        foundMatch = false;
-    }
-
-    yInfo() << "*** mapped joint names: ****";
-    for (size_t i = 0; i < m_robotJointsListNames.size(); i++)
-    {
-        yInfo() << "(" << i << ", " << m_humanToRobotMap[i] << "): " << m_robotJointsListNames[i]
-                << " , " << m_humanJointsListName[(m_humanToRobotMap[i])];
     }
 
     m_firstIteration = true;
@@ -179,8 +127,9 @@ bool XsensRetargeting::getJointValues()
 
     // in the msg thrift the first list is the joint names [get(0)], second the joint values
     // [get(1)]
-    yarp::os::Value humanjointsValueS = desiredHumanJoints->get(1);
-    yarp::os::Bottle* tmpHumanNewJointValues = humanjointsValueS.asList();
+
+    yarp::os::Value humanjointsValues = desiredHumanJoints->get(1);
+    yarp::os::Bottle* tmpHumanNewJointValues = humanjointsValues.asList();
 
     yarp::sig::Vector newJointValues;
     newJointValues.resize(m_actuatedDOFs, 0.0);
@@ -205,10 +154,57 @@ bool XsensRetargeting::getJointValues()
     {
         yInfo() << "[XsensRetargeting::getJointValues] Xsens Retargeting Module is Running ...";
         m_firstIteration = false;
+
+        /* We should do a maping between two vectors here: human and robot joint vectors, since
+         their order are not the same! */
+
+        // check the human joints name list
+        yarp::os::Value humanjointsNames = desiredHumanJoints->get(0);
+        yarp::os::Bottle* tmpHumanNewJointNames = humanjointsNames.asList();
+        if (tmpHumanNewJointNames->isNull())
+        {
+            yError() << "[XsensRetargeting::getJointValues()] Human joints name list is empty";
+            return false;
+        }
+
+        for (unsigned j = 0; j < tmpHumanNewJointNames->size(); j++)
+        {
+            m_humanJointsListName.push_back(tmpHumanNewJointNames->get(j).asString());
+        }
+
+        /* print human and robot joint name list */
+        yInfo() << "Human joints name list: [human joints list] [robot joints list]"
+                << m_humanJointsListName.size() << " , " << m_robotJointsListNames.size();
+
+        for (size_t i = 0; i < m_humanJointsListName.size(); i++)
+        {
+            if (i < m_robotJointsListNames.size())
+                yInfo() << "(" << i << "): " << m_humanJointsListName[i] << " , "
+                        << m_robotJointsListNames[i];
+            else
+            {
+                yInfo() << "(" << i << "): " << m_humanJointsListName[i] << " , --";
+            }
+        }
+        /* find the map between the human and robot joint list orders*/
+        if (!pImpl->mapJointsHDE2CONTROLLER(
+                m_robotJointsListNames, m_humanJointsListName, m_humanToRobotMap))
+        {
+            yError() << "[XsensRetargeting::getJointValues()] mapping is not possible";
+            return false;
+        }
+        if (m_humanToRobotMap.size() == 0)
+        {
+            yError() << "[XsensRetargeting::getJointValues()] m_humanToRobotMap.size is zero";
+        }
+
+        /* fill the robot joint list values*/
         for (unsigned j = 0; j < m_actuatedDOFs; j++)
         {
+
             newJointValues(j) = tmpHumanNewJointValues->get(m_humanToRobotMap[j]).asDouble();
             m_jointValues(j) = newJointValues(j);
+            yInfo() << " robot initial joint value: (" << j << "): " << m_jointValues[j];
         }
         m_WBTrajectorySmoother->init(m_jointValues);
     }
@@ -256,5 +252,45 @@ bool XsensRetargeting::updateModule()
 
 bool XsensRetargeting::close()
 {
+    return true;
+}
+bool XsensRetargeting::impl::mapJointsHDE2CONTROLLER(std::vector<std::string> robotJointsListNames,
+                                                     std::vector<std::string> humanJointsListName,
+                                                     std::vector<unsigned>& humanToRobotMap)
+{
+    if (!humanToRobotMap.empty())
+    {
+        humanToRobotMap.clear();
+    }
+
+    bool foundMatch = false;
+    for (unsigned i = 0; i < robotJointsListNames.size(); i++)
+    {
+        for (unsigned j = 0; j < humanJointsListName.size(); j++)
+        {
+
+            if (robotJointsListNames[i] == humanJointsListName[j])
+            {
+                foundMatch = true;
+                humanToRobotMap.push_back(j);
+                break;
+            }
+        }
+        if (!foundMatch)
+        {
+            yError() << "[XsensRetargeting::impl::mapJointsHDE2CONTROLLER] not found match for: "
+                     << robotJointsListNames[i] << " , " << i;
+            return false;
+        }
+        foundMatch = false;
+    }
+
+    yInfo() << "*** mapped joint names: ****";
+    for (size_t i = 0; i < robotJointsListNames.size(); i++)
+    {
+        yInfo() << "(" << i << ", " << humanToRobotMap[i] << "): " << robotJointsListNames[i]
+                << " , " << humanJointsListName[(humanToRobotMap[i])];
+    }
+
     return true;
 }


### PR DESCRIPTION
This PR fixes the following problems:
- [Get the joint names order for Xsens Retargeting online from the message instead of config file #88](https://github.com/dic-iit/element_retargeting-from-human/issues/88)
- Update the port names for the data coming from HDE for Xsens retargeting
- update the application files to run the HDE necessary devices for `humanStateProvider`