### PR TITLE
Manage CybSDK as other dependencies

### DIFF
--- a/cmake/WalkingTeleoperationFindDependencies.cmake
+++ b/cmake/WalkingTeleoperationFindDependencies.cmake
@@ -120,4 +120,8 @@ endmacro()
 find_package(HumanDynamicsEstimation QUIET)
 checkandset_dependency(HumanDynamicsEstimation)
 
+find_package(CybSDK QUIET)
+checkandset_dependency(CybSDK)
+
 WALKING_TELEOPERATION_dependent_option(WALKING_TELEOPERATION_COMPILE_XsensModule "Compile Xsens Module?" ON WALKING_TELEOPERATION_HAS_HumanDynamicsEstimation OFF)
+WALKING_TELEOPERATION_dependent_option(WALKING_TELEOPERATION_COMPILE_VirtualizerModule "Compile Virtualizer Module?" ON WALKING_TELEOPERATION_HAS_CybSDK OFF)

--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -9,6 +9,6 @@ if(WALKING_TELEOPERATION_COMPILE_XsensModule)
   add_subdirectory(Xsens_module)
 endif (WALKING_TELEOPERATION_COMPILE_XsensModule)
 
-if (MSVC)
+if(WALKING_TELEOPERATION_COMPILE_VirtualizerModule)
   add_subdirectory(Virtualizer_module)
-endif (MSVC)
+endif()

--- a/modules/Virtualizer_module/CMakeLists.txt
+++ b/modules/Virtualizer_module/CMakeLists.txt
@@ -8,13 +8,6 @@
 set(EXE_TARGET_NAME VirtualizerModule)
 
 
-find_package(CybSDK REQUIRED)
-if(NOT CybSDK_FOUND)
-  message( WARNING "${EXE_TARGET_NAME}: CybSDK Library is not found." )
-  return()
-endif()
-
-
 option(ENABLE_RPATH "Enable RPATH for this library" ON)
 mark_as_advanced(ENABLE_RPATH)
 include(AddInstallRPATHSupport)


### PR DESCRIPTION
Add the WALKING_TELEOPERATION_COMPILE_VirtualizerModule option to manage the compilation of the VirtualizerModule.

Once this is merged, we can just set WALKING_TELEOPERATION_COMPILE_VirtualizerModule to ON if ROBOTOLOGY_USES_CYBERITH_SDK  is ON, a give the ROBOTOLOGY_USES_CYBERITH_SDK  variable a reason to exist (see https://github.com/robotology/robotology-superbuild/issues/519). 