### PR TITLE
Add missing find_package(ICUB)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,9 @@ project(walking-teleoperation
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
-find_package(YARP REQUIRED)
 find_package(YCM REQUIRED)
+find_package(YARP REQUIRED)
+find_package(ICUB REQUIRED)
 include(WalkingTeleoperationFindDependencies)
 
 add_subdirectory(modules)


### PR DESCRIPTION
`ctrlLib`  was linked in https://github.com/robotology/walking-teleoperation/blob/master/modules/Xsens_module/CMakeLists.txt#L44, but `find_package(ICUB)` was never called. This was working fine for iDynTree < 3 as iDynTree was implicitly calling `find_package(ICUB)` , but now with iDynTree 3 is not working correctly anymore. 

See https://github.com/robotology/robotology-superbuild/runs/1830422805 for a failing run of the superbuild.