### PR TITLE
add rpc server to the oculus module to control finite state machine of the module

### DIFF
--- a/app/robots/iCubGazeboV2_5/oculusConfig.ini
+++ b/app/robots/iCubGazeboV2_5/oculusConfig.ini
@@ -6,6 +6,7 @@ rightHandPosePort       /rightHandPose:o
 playerOrientationPort   /playerOrientation:i
 rpcWalkingPort_name     /walkingRpc
 rpcVirtualizerPort_name /virtualizerRpc
+rpcServerOculusPort_name /oculusRpc
 
 [GENERAL]
 samplingTime            0.01

--- a/app/robots/iCubGenova04/oculusConfig.ini
+++ b/app/robots/iCubGenova04/oculusConfig.ini
@@ -6,6 +6,7 @@ rightHandPosePort       /rightHandPose:o
 playerOrientationPort   /playerOrientation:i
 rpcWalkingPort_name     /walkingRpc
 rpcVirtualizerPort_name /virtualizerRpc
+rpcServerOculusPort_name /oculusRpc
 
 [GENERAL]
 samplingTime            0.01

--- a/app/robots/iCubGenova09/oculusConfig.ini
+++ b/app/robots/iCubGenova09/oculusConfig.ini
@@ -6,6 +6,7 @@ rightHandPosePort       /rightHandPose:o
 playerOrientationPort   /playerOrientation:i
 rpcWalkingPort_name     /walkingRpc
 rpcVirtualizerPort_name /virtualizerRpc
+rpcServerOculusPort_name /oculusRpc
 
 [GENERAL]
 samplingTime            0.01

--- a/app/robots/icubGazeboSim/oculusConfig.ini
+++ b/app/robots/icubGazeboSim/oculusConfig.ini
@@ -6,6 +6,7 @@ rightHandPosePort       /rightHandPose:o
 playerOrientationPort   /playerOrientation:i
 rpcWalkingPort_name     /walkingRpc
 rpcVirtualizerPort_name /virtualizerRpc
+rpcServerOculusPort_name /oculusRpc
 
 [GENERAL]
 samplingTime            0.01

--- a/modules/Oculus_module/CMakeLists.txt
+++ b/modules/Oculus_module/CMakeLists.txt
@@ -45,13 +45,21 @@ set(${EXE_TARGET_NAME}_HDR
   include/OculusModule.hpp
   )
 
+set(${EXE_TARGET_NAME}_THRIFT_HDR
+  thrifts/TeleoperationCommands.thrift
+)
+
 # add include directories to the build.
 include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
+# Application target calls
+yarp_add_idl(${EXE_TARGET_NAME}_THRIFT_GEN_FILES ${${EXE_TARGET_NAME}_THRIFT_HDR})
+
 # add an executable to the project using the specified source files.
-add_executable(${EXE_TARGET_NAME} ${${EXE_TARGET_NAME}_SRC} ${${EXE_TARGET_NAME}_HDR})
+add_executable(${EXE_TARGET_NAME} ${${EXE_TARGET_NAME}_SRC} ${${EXE_TARGET_NAME}_HDR}
+    ${${EXE_TARGET_NAME}_THRIFT_GEN_FILES})
 
 if(ENABLE_LOGGER)
   target_link_libraries(${EXE_TARGET_NAME} LINK_PUBLIC

--- a/modules/Oculus_module/include/OculusModule.hpp
+++ b/modules/Oculus_module/include/OculusModule.hpp
@@ -273,21 +273,6 @@ public:
     bool runningModule();
 
     /**
-     * Respond to a message from the RPC port.
-     * @param command is the received message.
-     * The following message has to be a bottle with the following structure:
-     * 1. ("help");
-     * 2. ("prepare").
-     * 3. ("run")
-     * @param reply is the response of the server.
-     * 1. OK in case of success;
-     * 2. Not OK in case of failure.
-     * 3. list of available commands in case of "help" command
-     * @return true in case of success and false otherwise.
-     */
-    bool respond(const yarp::os::Bottle& command, yarp::os::Bottle& reply) final;
-
-    /**
      * to get the Oculus FSM in string format
      * @param OculusFSM to get the string value
      * @return string associated with the inpute sate

--- a/modules/Oculus_module/include/OculusModule.hpp
+++ b/modules/Oculus_module/include/OculusModule.hpp
@@ -22,6 +22,7 @@
 #include <yarp/os/BufferedPort.h>
 #include <yarp/os/RFModule.h>
 #include <yarp/os/RpcClient.h>
+#include <yarp/os/RpcServer.h>
 #include <yarp/sig/Vector.h>
 
 #include <FingersRetargeting.hpp>
@@ -129,11 +130,8 @@ private:
     yarp::os::RpcClient
         m_rpcVirtualizerClient; /**< Rpc client used for sending command to the virtualizer */
 
-    /** Port used to retrieve the human whole body joint pose. */
-    yarp::os::BufferedPort<yarp::os::Bottle> m_wholeBodyHumanJointsPort;
+    yarp::os::RpcServer m_rpcOculusServer; /**< RPC port to control Oculus FSM. */
 
-    /** Port used to retrieve the human whole body joint pose. */
-    yarp::os::BufferedPort<yarp::sig::Vector> m_wholeBodyHumanSmoothedJointsPort;
 
     double m_robotYaw; /**< Yaw angle of the robot base */
 
@@ -244,6 +242,28 @@ public:
      * @return true in case of success and false otherwise.
      */
     bool close() final;
+
+     /**
+     * Respond to a message from the RPC port.
+     * @param command is the received message.
+     * The following message has to be a bottle with the following structure:
+     * 1. ("help");
+     * 2. ("prepare").
+     * 3. ("run")
+     * @param reply is the response of the server.
+     * 1. OK in case of success;
+     * 2. Not OK in case of failure.
+     * 3. list of available commands in case of "help" command
+     * @return true in case of success and false otherwise.
+     */
+    bool respond(const yarp::os::Bottle& command, yarp::os::Bottle& reply) final;
+
+    /**
+     * to get the Oculus FSM in string format
+     * @param OculusFSM to get the string value
+     * @return string associated with the inpute sate
+     */
+    std::string getStringFromOculusState(const OculusFSM state);
 };
 
 inline std::string getTimeDateMatExtension()

--- a/modules/Oculus_module/src/OculusModule.cpp
+++ b/modules/Oculus_module/src/OculusModule.cpp
@@ -276,6 +276,8 @@ bool OculusModule::configureOculus(const yarp::os::Searchable& config)
 
 bool OculusModule::configure(yarp::os::ResourceFinder& rf)
 {
+    std::lock_guard<std::mutex> guard(m_mutex);
+
 #ifdef ENABLE_LOGGER
     yInfo() << "[OculusModule::configure] matlogger2 is eanbled!";
 #else
@@ -531,10 +533,7 @@ bool OculusModule::configure(yarp::os::ResourceFinder& rf)
         yInfo() << "[OculusModule::configure] Cameras have been reset.";
     }
 
-    {
-        std::lock_guard<std::mutex> guard(m_mutex);
-        m_state = OculusFSM::Configured;
-    }
+    m_state = OculusFSM::Configured;
 
     return true;
 }
@@ -546,6 +545,8 @@ double OculusModule::getPeriod()
 
 bool OculusModule::close()
 {
+    std::lock_guard<std::mutex> guard(m_mutex);
+
 #ifdef ENABLE_LOGGER
     if (m_enableLogger)
     {
@@ -633,7 +634,6 @@ bool OculusModule::runTeleoperation()
 
 bool OculusModule::preparingModule()
 {
-    std::lock_guard<std::mutex> guard(m_mutex);
     yarp::os::Bottle cmd, outcome;
     if (m_moveRobot)
     {
@@ -648,8 +648,6 @@ bool OculusModule::preparingModule()
 
 bool OculusModule::runningModule()
 {
-    std::lock_guard<std::mutex> guard(m_mutex);
-
     yarp::os::Bottle cmd, outcome;
 
     if (m_useOpenXr)

--- a/modules/Oculus_module/thrifts/TeleoperationCommands.thrift
+++ b/modules/Oculus_module/thrifts/TeleoperationCommands.thrift
@@ -1,0 +1,23 @@
+/**
+ * @file TeleoperationCommands.thrift
+ * @authors Kourosh Darvish <kourosh.darvish@iit.it>
+ * @copyright 2021 Artificial and Mechanical Intelligence Lab - Istituto Italiano di Tecnologia
+ *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ * @date 2021
+ */
+
+service TeleoperationCommands
+{
+    /**
+     * Call this method to prepare the Oculus Module for Teleoperation.
+     * @return true/false in case of success/failure;
+     */
+    bool prepareTeleoperation();
+
+    /**
+     * Run the entire Oculus Module for Teleoperation.
+     * @return true/false in case of success/failure;
+     */
+    bool runTeleoperation();
+
+}


### PR DESCRIPTION
Problem: 
Especially by using the VIVE, it is often tricky to distinguish the left from the right hand. It would be better and safer to start the teleoperation pipeline from a terminal command
Solution:
An RPC command is added to the oculus module.
