### PR TITLE
Add telemetry-logger application to Xprize semifinal pipeline

### DIFF
--- a/app/scripts/Xprize-KynDynRetargeting.xml
+++ b/app/scripts/Xprize-KynDynRetargeting.xml
@@ -12,12 +12,22 @@
   </authors>
 
   <!-- Modules -->
+
+  <module>
+    <name>yarprobotinterface</name>
+    <parameters>--config launch-yarp-robot-logger.xml</parameters>
+    <node>icub-console</node>
+    <workdir>/home/icub/Desktop/walking_logger</workdir>
+  </module>
+
   <module>
     <name>WalkingModule</name>
     <node>icub-head</node>
     <parameters>--from dcm_walking_iFeel_joint_retargeting.ini</parameters>
+    <dependencies>
+          <port timeout="15.0">/yarp-robot-logger/exogenous_signals/walking:i</port>
+    </dependencies>
   </module>
-
 
   <module>
     <name>VirtualizerModule</name>


### PR DESCRIPTION
Following https://github.com/ami-iit/component_ANA-Avatar-XPRIZE/issues/449, this PR is to launch the telemetry-logger application along with the other modules used in the XPrize semifinal pipeline.