### PR TITLE
Added config files for HapticGloveModule for iCubGazeboV3

### DIFF
--- a/app/robots/iCubGazeboV3/hapticGloveConfig.ini
+++ b/app/robots/iCubGazeboV3/hapticGloveConfig.ini
@@ -1,0 +1,30 @@
+name                    HapticGloveRetargeting
+
+
+[GENERAL]
+robot                   icubSim
+samplingTime            0.01
+enableMoveRobot         1
+enableLogger            1
+useLeftHand             1
+useRightHand            1
+smoothingTime           0.25
+isMandatory             0
+useSkin                 0
+#calibrationTimePeriod [sec]
+calibrationTimePeriod   2.0
+#robotInitializationTime [sec]
+robotInitializationTime 10.0
+getHumanMotionRange     1
+# the counter to check if steady state is reached [steps]
+steadyStateCounterThreshold 5
+# the threshold to check the error between the desired and feedback values for the steady state check [rad]
+steadyStateThreshold        0.05
+# the time teleoperation should wait before running [sec]
+waitingDurationTime         5.0
+# threshold in which an skin is considered as working fine [no units]
+tactileWorkingThreshold     0.0001
+
+# include fingers parameters
+[include LEFT_FINGERS_RETARGETING   "leftFingersHapticRetargetingParams.ini"]
+[include RIGHT_FINGERS_RETARGETING "rightFingersHapticRetargetingParams.ini"]

--- a/app/robots/iCubGazeboV3/leftFingersHapticRetargetingParams.ini
+++ b/app/robots/iCubGazeboV3/leftFingersHapticRetargetingParams.ini
@@ -1,0 +1,167 @@
+###############
+### ROBOT
+###############
+remote_control_boards   ("left_arm")
+
+remote_sensor_boards    "left_hand"
+
+axis_list             (  "l_hand_fingers", "l_thumb_oppose", "l_thumb_proximal", "l_thumb_distal", "l_index_proximal", "l_index_distal" , "l_middle_proximal" , "l_middle_distal" , "l_pinky" )
+
+all_axis_list         (  "l_hand_fingers", "l_thumb_oppose", "l_thumb_proximal", "l_thumb_distal", "l_index_proximal", "l_index_distal" , "l_middle_proximal" , "l_middle_distal" , "l_pinky" )
+
+joint_list                   (  "l_thumb_oppose",    "l_thumb_proximal", "l_thumb_middle", "l_thumb_distal",
+                                "l_index_abduction", "l_index_proximal", "l_index_middle", "l_index_distal",
+                                "l_middle_proximal", "l_middle_middle", "l_middle_distal",
+                                "l_ring_abduction",  "l_ring_proximal",   "l_ring_middle",  "l_ring_distal",
+                                "l_pinky_abduction", "l_pinky_proximal",  "l_pinky_middle", "l_pinky_distal" )
+
+# the custom range of axes motion [degrees]
+#                        axis-name ,         min value,     max value
+axes_custom_motion_range  (   ( "l_thumb_oppose" ,  10,            90) )
+
+# the custom axes home angle value [degrees]
+# By default it home values are set to min axis values
+#                        axis-name ,         axis value
+axes_custom_home_angle  (   ( "l_thumb_oppose" ,  30) )
+
+# if a joint is not listed here, the sensory information is of encoder type.
+# notice that "l_thumb_oppose" and "l_hand_fingers" is measured by joint encoders not the analog sensors
+analog_list           (  "l_thumb_proximal", "l_thumb_middle", "l_thumb_distal",
+                         "l_index_proximal", "l_index_middle", "l_index_distal",
+                         "l_middle_proximal", "l_middle_middle", "l_middle_distal",
+                         "l_ring_proximal",   "l_ring_middle",   "l_ring_distal",
+                         "l_pinky_proximal",   "l_pinky_middle",   "l_pinky_distal" )
+
+# notice that "l_thumb_oppose" is measured by joint encoders not the analog sensors
+#Adding the groups of each axis and associated analog sensors
+l_hand_fingers         ( "l_index_abduction", "l_ring_abduction", "l_pinky_abduction")
+l_thumb_oppose         ( "l_thumb_oppose" )
+l_thumb_proximal       ( "l_thumb_proximal" )
+l_thumb_distal         ( "l_thumb_middle", "l_thumb_distal"  )
+l_index_proximal       ( "l_index_proximal" )
+l_index_distal         (  "l_index_middle", "l_index_distal" )
+l_middle_proximal      (  "l_middle_proximal" )
+l_middle_distal        ( "l_middle_middle", "l_middle_distal" )
+l_pinky                ( "l_ring_proximal", "l_ring_middle", "l_ring_distal", "l_pinky_proximal", "l_pinky_middle", "l_pinky_distal" )
+
+robot_finger_list ( "l_thumb_finger", "l_index_finger", "l_middle_finger", "l_ring_finger", "l_little_finger")
+
+###############
+### HUMAN
+###############
+human_joint_list      ( "l_thumb_oppose",     "l_thumb_proximal",  "l_thumb_middle",   "l_thumb_distal",
+                        "l_index_abduction",  "l_index_proximal",  "l_index_middle",   "l_index_distal",
+                        "l_middle_abduction", "l_middle_proximal", "l_middle_middle",  "l_middle_distal",
+                        "l_ring_abduction",   "l_ring_proximal",   "l_ring_middle",    "l_ring_distal",
+                        "l_pinky_abduction",  "l_pinky_proximal",  "l_pinky_middle",   "l_pinky_distal" )
+
+human_finger_list ( "l_thumb_finger", "l_index_finger", "l_middle_finger", "l_ring_finger", "l_little_finger")
+
+hand_link           l_hand
+
+wearable_data_ports ("/WearableData/HapticGlove/LeftHand/data:o")
+
+use_rpc               0
+
+wearable_rpc_ports ( "/WearableData/HapticGlove/LeftHand/metadataRpc:o" )
+
+wearable_data_actuator_ports_out "/WearableData/HapticGlove/LeftHand/Actuators/input:o"
+
+wearable_data_actuator_ports_in "/WearableData/HapticGlove/LeftHand/Actuators/input:i"
+
+###############
+### RETARGETING
+###############
+
+motorsJointsCoupled      1
+
+# haptic feedback retargeting from the robot axis groups to the human finger
+l_thumb_finger                  ( "l_thumb_oppose", "l_thumb_proximal", "l_thumb_distal"  )
+l_index_finger                  ( "l_hand_fingers", "l_index_proximal", "l_index_distal"  )
+l_middle_finger                 ( "l_middle_proximal", "l_middle_distal"  )
+l_ring_finger                   (  "l_pinky" )
+l_little_finger                 (  "l_pinky" )
+
+# This gain is multiplied to the total error for each motor/axis to compute the force feedback to the user associated with each axis,
+# defined according to user experience
+# Number of gains = number of motors/axis
+gainTotalError            ( 0.0 0.0 600.0   600.0 600.0 600.0   600.0 600.0 600.0 )
+
+# check this issue for the velocity Gain: https://github.com/dic-iit/element_retargeting-from-human/issues/141
+# number of gains = number of motors/axis
+gainVelocityError         ( 0.0 0.0 0.1   0.1 0.1 0.1   0.1 0.1 0.1 )
+
+# this value is multiplied to force feedback and provides haptic feedback to the user
+# number of gains =  number of fingers
+gainVibrotactile          ( 0.8 0.8 0.8 0.8 0.8 )
+
+# scaling and biased values for maping the human to robot motion
+human_to_robot_joint_angles_scaling (  -1.0 1.0 1.0 1.0
+                                        1.0 1.0 1.0 1.0
+                                        1.0 1.0 1.0
+                                       -1.0 1.0 1.0 1.0
+                                       -1.0 1.0 1.0 1.0 )
+
+human_to_robot_joint_anlges_bias    (  0.0 0.0 0.0 0.0
+                                       0.0 0.0 0.0 0.0
+                                       0.0 0.0 0.0
+                                       0.0 0.0 0.0 0.0
+                                       0.0 0.0 0.0 0.0  )
+
+axisContactThreshold                 0.1
+
+##############################
+### ROBOT CONTROL & ESTIMATION
+##############################
+useVelocity           0
+
+referenceVelocityForPositionControl 80.0
+
+
+# minimum and maximum values of the joints
+# related to analog sensors
+# values are in degrees
+analog_joints_min_boundary      ( 0.0   0.0   0.0      0.0   0.0   0.0      0.0   0.0   0.0      0.0   0.0   0.0      0.0   0.0   0.0  )
+analog_joints_max_boundary      ( 90.0  90.0  90.0     90.0  90.0  90.0     90.0  90.0  90.0     90.0  90.0  90.0     90.0  90.0  90.0 )
+
+analog_sensors_raw_min_boundary ( 255.0 255.0 255.0    255.0 255.0 255.0    255.0 255.0 255.0    255.0 255.0 255.0    255.0 255.0 255.0 )
+analog_sensors_raw_max_boundary ( 0.0   0.0   0.0      0.0   0.0   0.0      0.0   0.0   0.0      0.0   0.0   0.0      0.0   0.0   0.0 )
+
+
+# in case each joint does not have independant motor to actuate, they are coupled
+axesJointsCoupled     1
+
+doCalibration           1
+
+#robot controller exponential filter gain
+exponentialFilterGain           0.9
+
+# q= A x m, where:
+#       q (n,1) is the joint values
+#       m (m,1) is the axis/motors values
+#       A (n,m) is the mapping from the motors values to the joint values
+# CouplingMatrix = A : (n,m) matrix
+# if doCalibration is true, then the CouplingMatrix will be over-written
+CouplingMatrix          ( 1.1 0.0 0.0 0.0 0.0
+                          0.0 1.0 1.0 0.0 0.0
+                          0.0 0.0 1.0 0.0 0.0
+                          0.0 0.0 0.0 0.0 1.0 )
+
+# in the Quadratic optimizartion problem to compute the motor values from the joint values : xT Q X + uT R u
+# q_matrix_joint_motor is the list identifying the main diagonal of matrix Q: (q x q) matrix; q: is the number of desired joints to control
+# r_matrix_joint_motor is the list identifying the main diagonal of matrix R: (m x m) matrix; m: is the number of desired motors to control
+
+# for joint-axis qp controller
+# eqaul to the number of all joints
+q_qp_control    ( 1.0 1.0 1.0 1.0    1.0 1.0 1.0 1.0    1.0 1.0 1.0    1.0 1.0 1.0 1.0    1.0 1.0 1.0 1.0 )
+
+# eqaul to the number of all axes
+r_qp_control    ( 0.0 0.0 0.0   0.0 0.0 0.0   0.0 0.0 0.0 )
+
+# in the Kalman Filter problem to estimate the motor value, velocity and acceleration:
+# q_matrix_kf is the list identifying the main diagonal of matrix: E[ (w(t) -w_bar(t)) (w(t) -w_bar(t))^T ], size:  m*m positive matrix,  Dx(t)= Fx(t)+ Gw(t), the process noise */
+# r_matrix_kf is the list identifying the main diagonal of matrix: E[ v(t) v(t)^T ], size:  p*p positive matrix, Z(t)= Hx(t)+ v(t), the measurement noise
+no_states_kf            3
+no_measurement_kf       1
+q_matrix_kf             ( 10.0 150.0 100000.0 )
+r_matrix_kf             ( 0.0000001 )

--- a/app/robots/iCubGazeboV3/rightFingersHapticRetargetingParams.ini
+++ b/app/robots/iCubGazeboV3/rightFingersHapticRetargetingParams.ini
@@ -1,0 +1,168 @@
+###############
+### ROBOT
+###############
+
+remote_control_boards   ("right_arm")
+
+remote_sensor_boards    "right_hand"
+
+axis_list             (  "r_hand_fingers", "r_thumb_oppose", "r_thumb_proximal", "r_thumb_distal", "r_index_proximal", "r_index_distal", "r_middle_proximal", "r_middle_distal", "r_pinky" )
+
+all_axis_list         (  "r_hand_fingers", "r_thumb_oppose", "r_thumb_proximal", "r_thumb_distal", "r_index_proximal", "r_index_distal", "r_middle_proximal", "r_middle_distal", "r_pinky" )
+
+
+joint_list            (  "r_thumb_oppose",    "r_thumb_proximal", "r_thumb_middle", "r_thumb_distal",
+                         "r_index_abduction", "r_index_proximal",  "r_index_middle",   "r_index_distal",
+                         "r_middle_proximal", "r_middle_middle",  "r_middle_distal",
+                         "r_ring_abduction",  "r_ring_proximal",   "r_ring_middle",    "r_ring_distal",
+                         "r_pinky_abduction", "r_pinky_proximal",  "r_pinky_middle",   "r_pinky_distal" )
+
+# the custom range of axes motion [degrees]
+#                        axis-name ,         min value,     max value
+axes_custom_motion_range  (   ( "r_thumb_oppose" ,  10,            90) )
+
+# the custom axes home angle value [degrees]
+# By default it home values are set to min axis values
+#                        axis-name ,         axis value
+axes_custom_home_angle  (   ( "r_thumb_oppose" ,  30) )
+
+# if a joint is not listed here, the sensory information is of encoder type.
+# notice that "r_thumb_oppose" and "r_hand_fingers" is measured by joint encoders not the analog sensors
+analog_list           (  "r_thumb_proximal",  "r_thumb_middle", "r_thumb_distal",
+                         "r_index_proximal",  "r_index_middle", "r_index_distal",
+                         "r_middle_proximal", "r_middle_middle", "r_middle_distal",
+                         "r_ring_proximal",   "r_ring_middle",   "r_ring_distal",
+                         "r_pinky_proximal",  "r_pinky_middle",   "r_pinky_distal" )
+
+#Adding the groups of each axis and associated analog sensors
+r_hand_fingers          ( "r_index_abduction", "r_ring_abduction", "r_pinky_abduction")
+r_thumb_oppose         ( "r_thumb_oppose" )
+r_thumb_proximal       ( "r_thumb_proximal" )
+r_thumb_distal         ( "r_thumb_middle", "r_thumb_distal"  )
+r_index_proximal       ( "r_index_proximal" )
+r_index_distal         ( "r_index_middle", "r_index_distal" )
+r_middle_proximal      ( "r_middle_proximal" )
+r_middle_distal        ( "r_middle_middle", "r_middle_distal" )
+r_pinky                ( "r_ring_proximal",   "r_ring_middle",   "r_ring_distal", "r_pinky_proximal",   "r_pinky_middle",   "r_pinky_distal" )
+
+robot_finger_list ( "r_thumb_finger", "r_index_finger", "r_middle_finger", "r_ring_finger", "r_little_finger")
+###############
+### HUMAN
+###############
+human_joint_list      ( "r_thumb_oppose", "r_thumb_proximal", "r_thumb_middle", "r_thumb_distal",
+                         "r_index_abduction", "r_index_proximal", "r_index_middle", "r_index_distal",
+                         "r_middle_abduction", "r_middle_proximal", "r_middle_middle", "r_middle_distal",
+                         "r_ring_abduction",  "r_ring_proximal",   "r_ring_middle",   "r_ring_distal",
+                         "r_pinky_abduction", "r_pinky_proximal",   "r_pinky_middle",   "r_pinky_distal" )
+
+human_finger_list ( "r_thumb_finger", "r_index_finger", "r_middle_finger", "r_ring_finger", "r_little_finger")
+
+hand_link           r_hand
+
+
+wearable_data_ports ("/WearableData/HapticGlove/RightHand/data:o")
+
+use_rpc               0
+
+wearable_rpc_ports ( "/WearableData/HapticGlove/RightHand/metadataRpc:o" )
+
+wearable_data_actuator_ports_out "/WearableData/HapticGlove/RightHand/Actuators/input:o"
+
+wearable_data_actuator_ports_in "/WearableData/HapticGlove/RightHand/Actuators/input:i"
+
+###############
+### RETARGETING
+###############
+
+motorsJointsCoupled      1
+
+# haptic feedback retargeting from the robot axis groups to the human finger
+r_thumb_finger                  (  "r_thumb_oppose", "r_thumb_proximal", "r_thumb_distal"  )
+r_index_finger                  (  "r_hand_finger",  "r_index_proximal", "r_index_distal"  )
+r_middle_finger                 (  "r_middle_proximal", "r_middle_distal"  )
+r_ring_finger                   (  "r_pinky" )
+r_little_finger                 (  "r_pinky" )
+
+# This gain is multiplied to the total error for each motor/axis to compute the force feedback to the user associated with each axis,
+# defined according to user experience
+# Number of gains = number of motors/axis
+gainTotalError            ( 0.0 0.0 600.0   600.0 600.0 600.0   600.0 600.0 600.0 )
+
+# check this issue for the velocity Gain: https://github.com/dic-iit/element_retargeting-from-human/issues/141
+# number of gains = number of motors/axis
+gainVelocityError         ( 0.0 0.0 0.1   0.1 0.1 0.1   0.1 0.1 0.1 )
+
+# this value is multiplied to forcefeedback and provides haptic feedback to the user
+# number of gains =  number of fingers
+gainVibrotactile          ( 0.8 0.8 0.8 0.8 0.8 )
+
+# scaling and biased values for maping the human to robot motion
+human_to_robot_joint_angles_scaling (  1.0 1.0 1.0 1.0
+                                       -1.0 1.0 1.0 1.0
+                                        1.0 1.0 1.0
+                                       1.0 1.0 1.0 1.0
+                                       1.0 1.0 1.0 1.0 )
+
+human_to_robot_joint_anlges_bias    (  0.0 0.0 0.0 0.0
+                                       0.0 0.0 0.0 0.0
+                                       0.0 0.0 0.0
+                                       0.0 0.0 0.0 0.0
+                                       0.0 0.0 0.0 0.0  )
+
+axisContactThreshold                 0.1
+
+##############################
+### ROBOT CONTROL & ESTIMATION
+##############################
+useVelocity           0
+
+referenceVelocityForPositionControl 80.0
+
+# minimum and maximum values of the joints
+# related to analog sensors
+# values are in degrees
+analog_joints_min_boundary      ( 0.0   0.0   0.0      0.0   0.0   0.0      0.0   0.0   0.0      0.0   0.0   0.0      0.0   0.0   0.0  )
+analog_joints_max_boundary      ( 90.0  90.0  90.0     90.0  90.0  90.0     90.0  90.0  90.0     90.0  90.0  90.0     90.0  90.0  90.0 )
+
+analog_sensors_raw_min_boundary ( 255.0 255.0 255.0    255.0 255.0 255.0    255.0 255.0 255.0    255.0 255.0 255.0    255.0 255.0 255.0 )
+analog_sensors_raw_max_boundary ( 0.0   0.0   0.0      0.0   0.0   0.0      0.0   0.0   0.0      0.0   0.0   0.0      0.0   0.0   0.0 )
+
+# in case each joint does not have independant motor to actuate, they are coupled
+axesJointsCoupled     1
+
+doCalibration           1
+
+#robot controller exponential filter gain
+exponentialFilterGain           0.9
+
+# q= A x m, where:
+#       q (n,1) is the joint values
+#       m (m,1) is the axis/motor values
+#       A (n,m) is the mapping from the motors values to the joint values
+
+# CouplingMatrix = A : (n,m) matrix
+# if doCalibration is true, then the CouplingMatrix will be over-written
+CouplingMatrix          ( 1.1 0.0 0.0 0.0 0.0
+                          0.0 1.0 1.0 0.0 0.0
+                          0.0 0.0 1.0 0.0 0.0
+                          0.0 0.0 0.0 0.0 1.0 )
+
+# in the Quadratic optimizartion problem to compute the motor values from the joint values : xT Q X + uT R u
+# q_matrix_joint_motor is the list identifying the main diagonal of matrix Q: (q x q) matrix; q: is the number of desired joints to control
+# r_matrix_joint_motor is the list identifying the main diagonal of matrix R: (m x m) matrix; m: is the number of desired motors to control
+
+# for joint-axis qp controller
+# eqaul to the number of all joints
+q_qp_control    ( 1.0 1.0 1.0 1.0    1.0 1.0 1.0 1.0    1.0 1.0 1.0    1.0 1.0 1.0 1.0    1.0 1.0 1.0 1.0 )
+
+
+# eqaul to the number of all axes
+r_qp_control    ( 0.0 0.0 0.0   0.0 0.0 0.0   0.0 0.0 0.0 )
+
+# in the Kalman Filter problem to estimate the motor value, velocity and acceleration:
+# q_matrix_kf is the list identifying the main diagonal of matrix: E[ (w(t) -w_bar(t)) (w(t) -w_bar(t))^T ], size:  m*m positive matrix,  Dx(t)= Fx(t)+ Gw(t), the process noise */
+# r_matrix_kf is the list identifying the main diagonal of matrix: E[ v(t) v(t)^T ], size:  p*p positive matrix, Z(t)= Hx(t)+ v(t), the measurement noise
+no_states_kf            3
+no_measurement_kf       1
+q_matrix_kf             ( 10.0 150.0 100000.0 )
+r_matrix_kf             ( 0.0000001 )


### PR DESCRIPTION
Enables using the HapticGlove (SenseGlove) in simulations with the new `iCubGazeboV3_visiuomanip`
See https://github.com/ami-iit/component_ANA-Avatar-XPRIZE/issues/570
related https://github.com/robotology/icub-models/pull/170