### PR TITLE
Remove deprecated parameters in iWearRemapper

### DIFF
--- a/app/robots/iCubErzelli02/leftFingersHapticRetargetingParams.ini
+++ b/app/robots/iCubErzelli02/leftFingersHapticRetargetingParams.ini
@@ -50,10 +50,6 @@ hand_link           l_hand
 
 wearable_data_ports ("/WearableData/HapticGlove/LeftHand/data:o")
 
-use_rpc               0
-
-wearable_rpc_ports ( "/WearableData/HapticGlove/LeftHand/metadataRpc:o" )
-
 wearable_data_actuator_ports_out "/WearableData/HapticGlove/LeftHand/Actuators/input:o"
 
 wearable_data_actuator_ports_in "/WearableData/HapticGlove/LeftHand/Actuators/input:i"

--- a/app/robots/iCubErzelli02/rightFingersHapticRetargetingParams.ini
+++ b/app/robots/iCubErzelli02/rightFingersHapticRetargetingParams.ini
@@ -50,10 +50,6 @@ hand_link           r_hand
 
 wearable_data_ports ("/WearableData/HapticGlove/RightHand/data:o")
 
-use_rpc               0
-
-wearable_rpc_ports ( "/WearableData/HapticGlove/RightHand/metadataRpc:o" )
-
 wearable_data_actuator_ports_out "/WearableData/HapticGlove/RightHand/Actuators/input:o"
 
 wearable_data_actuator_ports_in "/WearableData/HapticGlove/RightHand/Actuators/input:i"

--- a/app/robots/iCubGazeboV2_5/leftFingersHapticRetargetingParams.ini
+++ b/app/robots/iCubGazeboV2_5/leftFingersHapticRetargetingParams.ini
@@ -60,10 +60,6 @@ hand_link           l_hand
 
 wearable_data_ports ("/WearableData/HapticGlove/LeftHand/data:o")
 
-use_rpc               0
-
-wearable_rpc_ports ( "/WearableData/HapticGlove/LeftHand/metadataRpc:o" )
-
 wearable_data_actuator_ports_out "/WearableData/HapticGlove/LeftHand/Actuators/input:o"
 
 wearable_data_actuator_ports_in "/WearableData/HapticGlove/LeftHand/Actuators/input:i"

--- a/app/robots/iCubGazeboV2_5/rightFingersHapticRetargetingParams.ini
+++ b/app/robots/iCubGazeboV2_5/rightFingersHapticRetargetingParams.ini
@@ -60,10 +60,6 @@ hand_link           r_hand
 
 wearable_data_ports ("/WearableData/HapticGlove/RightHand/data:o")
 
-use_rpc               0
-
-wearable_rpc_ports ( "/WearableData/HapticGlove/RightHand/metadataRpc:o" )
-
 wearable_data_actuator_ports_out "/WearableData/HapticGlove/RightHand/Actuators/input:o"
 
 wearable_data_actuator_ports_in "/WearableData/HapticGlove/RightHand/Actuators/input:i"

--- a/app/robots/iCubGazeboV3/leftFingersHapticRetargetingParams.ini
+++ b/app/robots/iCubGazeboV3/leftFingersHapticRetargetingParams.ini
@@ -61,10 +61,6 @@ hand_link           l_hand
 
 wearable_data_ports ("/WearableData/HapticGlove/LeftHand/data:o")
 
-use_rpc               0
-
-wearable_rpc_ports ( "/WearableData/HapticGlove/LeftHand/metadataRpc:o" )
-
 wearable_data_actuator_ports_out "/WearableData/HapticGlove/LeftHand/Actuators/input:o"
 
 wearable_data_actuator_ports_in "/WearableData/HapticGlove/LeftHand/Actuators/input:i"

--- a/app/robots/iCubGazeboV3/rightFingersHapticRetargetingParams.ini
+++ b/app/robots/iCubGazeboV3/rightFingersHapticRetargetingParams.ini
@@ -62,10 +62,6 @@ hand_link           r_hand
 
 wearable_data_ports ("/WearableData/HapticGlove/RightHand/data:o")
 
-use_rpc               0
-
-wearable_rpc_ports ( "/WearableData/HapticGlove/RightHand/metadataRpc:o" )
-
 wearable_data_actuator_ports_out "/WearableData/HapticGlove/RightHand/Actuators/input:o"
 
 wearable_data_actuator_ports_in "/WearableData/HapticGlove/RightHand/Actuators/input:i"

--- a/app/robots/iCubGenova04/leftFingersHapticRetargetingParams.ini
+++ b/app/robots/iCubGenova04/leftFingersHapticRetargetingParams.ini
@@ -60,10 +60,6 @@ hand_link           l_hand
 
 wearable_data_ports ("/WearableData/HapticGlove/LeftHand/data:o")
 
-use_rpc               0
-
-wearable_rpc_ports ( "/WearableData/HapticGlove/LeftHand/metadataRpc:o" )
-
 wearable_data_actuator_ports_out "/WearableData/HapticGlove/LeftHand/Actuators/input:o"
 
 wearable_data_actuator_ports_in "/WearableData/HapticGlove/LeftHand/Actuators/input:i"

--- a/app/robots/iCubGenova04/rightFingersHapticRetargetingParams.ini
+++ b/app/robots/iCubGenova04/rightFingersHapticRetargetingParams.ini
@@ -59,10 +59,6 @@ hand_link           r_hand
 
 wearable_data_ports ("/WearableData/HapticGlove/RightHand/data:o")
 
-use_rpc               0
-
-wearable_rpc_ports ( "/WearableData/HapticGlove/RightHand/metadataRpc:o" )
-
 wearable_data_actuator_ports_out "/WearableData/HapticGlove/RightHand/Actuators/input:o"
 
 wearable_data_actuator_ports_in "/WearableData/HapticGlove/RightHand/Actuators/input:i"

--- a/app/robots/iCubGenova09/leftFingersHapticRetargetingParams.ini
+++ b/app/robots/iCubGenova09/leftFingersHapticRetargetingParams.ini
@@ -60,10 +60,6 @@ hand_link           l_hand
 
 wearable_data_ports ("/WearableData/HapticGlove/LeftHand/data:o")
 
-use_rpc               0
-
-wearable_rpc_ports ( "/WearableData/HapticGlove/LeftHand/metadataRpc:o" )
-
 wearable_data_actuator_ports_out "/WearableData/HapticGlove/LeftHand/Actuators/input:o"
 
 wearable_data_actuator_ports_in "/WearableData/HapticGlove/LeftHand/Actuators/input:i"

--- a/app/robots/iCubGenova09/rightFingersHapticRetargetingParams.ini
+++ b/app/robots/iCubGenova09/rightFingersHapticRetargetingParams.ini
@@ -60,10 +60,6 @@ hand_link           r_hand
 
 wearable_data_ports ("/WearableData/HapticGlove/RightHand/data:o")
 
-use_rpc               0
-
-wearable_rpc_ports ( "/WearableData/HapticGlove/RightHand/metadataRpc:o" )
-
 wearable_data_actuator_ports_out "/WearableData/HapticGlove/RightHand/Actuators/input:o"
 
 wearable_data_actuator_ports_in "/WearableData/HapticGlove/RightHand/Actuators/input:i"

--- a/app/robots/icubGazeboSim/leftFingersHapticRetargetingParams.ini
+++ b/app/robots/icubGazeboSim/leftFingersHapticRetargetingParams.ini
@@ -59,10 +59,6 @@ hand_link           l_hand
 
 wearable_data_ports ("/WearableData/HapticGlove/LeftHand/data:o")
 
-use_rpc               0
-
-wearable_rpc_ports ( "/WearableData/HapticGlove/LeftHand/metadataRpc:o" )
-
 wearable_data_actuator_ports_out "/WearableData/HapticGlove/LeftHand/Actuators/input:o"
 
 wearable_data_actuator_ports_in "/WearableData/HapticGlove/LeftHand/Actuators/input:i"

--- a/app/robots/icubGazeboSim/rightFingersHapticRetargetingParams.ini
+++ b/app/robots/icubGazeboSim/rightFingersHapticRetargetingParams.ini
@@ -58,13 +58,6 @@ human_finger_list ( "r_thumb_finger", "r_index_finger", "r_middle_finger", "r_ri
 
 hand_link           r_hand
 
-
-wearable_data_ports ("/WearableData/HapticGlove/RightHand/data:o")
-
-use_rpc               0
-
-wearable_rpc_ports ( "/WearableData/HapticGlove/RightHand/metadataRpc:o" )
-
 wearable_data_actuator_ports_out "/WearableData/HapticGlove/RightHand/Actuators/input:o"
 
 wearable_data_actuator_ports_in "/WearableData/HapticGlove/RightHand/Actuators/input:i"


### PR DESCRIPTION
The RPC port was removed in https://github.com/robotology/wearables/pull/131, and it is not used. I am removing it from the HapticGlove configuration files