### PR TITLE
Remove unused field in HapticGloveModule actuator msg

### DIFF
--- a/modules/HapticGlove_module/src/GloveWearable.cpp
+++ b/modules/HapticGlove_module/src/GloveWearable.cpp
@@ -352,7 +352,6 @@ bool GloveWearableImpl::setFingertipForceFeedbackValues(const std::vector<int>& 
                                             + wearable::actuator::IHaptic::getPrefix() + fingerName
                                             + "::ForceFeedback";
         wearableActuatorCommand.info.type = wearable::msg::ActuatorType::HAPTIC;
-        wearableActuatorCommand.info.status = wearable::msg::ActuatorStatus::OK;
         wearableActuatorCommand.duration = 0;
 
         m_iWearActuatorPort.write(true); // writeStrict option for wearable haptic device should be
@@ -384,7 +383,6 @@ bool GloveWearableImpl::setFingertipVibrotactileValues(const std::vector<int>& v
                                             + "::VibroTactileFeedback";
 
         wearableActuatorCommand.info.type = wearable::msg::ActuatorType::HAPTIC;
-        wearableActuatorCommand.info.status = wearable::msg::ActuatorStatus::OK;
         wearableActuatorCommand.duration = 0;
 
         m_iWearActuatorPort.write(true); // writeStrict option for wearable haptic device should be
@@ -416,7 +414,6 @@ bool GloveWearableImpl::setPalmVibrotactileValue(const int& value)
     wearableActuatorCommand.info.name = m_wearablePrefix + wearable::actuator::IHaptic::getPrefix()
                                         + m_handLinkName + "::VibroTactileFeedback";
     wearableActuatorCommand.info.type = wearable::msg::ActuatorType::HAPTIC;
-    wearableActuatorCommand.info.status = wearable::msg::ActuatorStatus::OK;
     wearableActuatorCommand.duration = 0;
 
     m_iWearActuatorPort.write(false);


### PR DESCRIPTION
This PR to remove unused fields of the wearables actuators message that are not really used.

After https://github.com/robotology/wearables/pull/171 is merged, the CI checks won't pass anymore if the lines addressed by this PR are not removed.