### PR TITLE
License the repo under the BSD-3-Clause license

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
-# Copyright (C) 2018 Fondazione Istituto Italiano di Tecnologia (IIT)
-# All Rights Reserved.
-# Authors: Giulio Romualdi <giulio.romualdi@iit.it>
+# SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+# SPDX-License-Identifier: BSD-3-Clause
 
 cmake_minimum_required(VERSION 3.5)
 set(CMAKE_CXX_STANDARD 14)

--- a/LICENSE
+++ b/LICENSE
@@ -1,165 +1,28 @@
-                   GNU LESSER GENERAL PUBLIC LICENSE
-                       Version 3, 29 June 2007
+BSD 3-Clause License
 
- Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
- Everyone is permitted to copy and distribute verbatim copies
- of this license document, but changing it is not allowed.
+Copyright (c) Fondazione Istituto Italiano di Tecnologia (IIT)
 
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
-  This version of the GNU Lesser General Public License incorporates
-the terms and conditions of version 3 of the GNU General Public
-License, supplemented by the additional permissions listed below.
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
 
-  0. Additional Definitions.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
 
-  As used herein, "this License" refers to version 3 of the GNU Lesser
-General Public License, and the "GNU GPL" refers to version 3 of the GNU
-General Public License.
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
 
-  "The Library" refers to a covered work governed by this License,
-other than an Application or a Combined Work as defined below.
-
-  An "Application" is any work that makes use of an interface provided
-by the Library, but which is not otherwise based on the Library.
-Defining a subclass of a class defined by the Library is deemed a mode
-of using an interface provided by the Library.
-
-  A "Combined Work" is a work produced by combining or linking an
-Application with the Library.  The particular version of the Library
-with which the Combined Work was made is also called the "Linked
-Version".
-
-  The "Minimal Corresponding Source" for a Combined Work means the
-Corresponding Source for the Combined Work, excluding any source code
-for portions of the Combined Work that, considered in isolation, are
-based on the Application, and not on the Linked Version.
-
-  The "Corresponding Application Code" for a Combined Work means the
-object code and/or source code for the Application, including any data
-and utility programs needed for reproducing the Combined Work from the
-Application, but excluding the System Libraries of the Combined Work.
-
-  1. Exception to Section 3 of the GNU GPL.
-
-  You may convey a covered work under sections 3 and 4 of this License
-without being bound by section 3 of the GNU GPL.
-
-  2. Conveying Modified Versions.
-
-  If you modify a copy of the Library, and, in your modifications, a
-facility refers to a function or data to be supplied by an Application
-that uses the facility (other than as an argument passed when the
-facility is invoked), then you may convey a copy of the modified
-version:
-
-   a) under this License, provided that you make a good faith effort to
-   ensure that, in the event an Application does not supply the
-   function or data, the facility still operates, and performs
-   whatever part of its purpose remains meaningful, or
-
-   b) under the GNU GPL, with none of the additional permissions of
-   this License applicable to that copy.
-
-  3. Object Code Incorporating Material from Library Header Files.
-
-  The object code form of an Application may incorporate material from
-a header file that is part of the Library.  You may convey such object
-code under terms of your choice, provided that, if the incorporated
-material is not limited to numerical parameters, data structure
-layouts and accessors, or small macros, inline functions and templates
-(ten or fewer lines in length), you do both of the following:
-
-   a) Give prominent notice with each copy of the object code that the
-   Library is used in it and that the Library and its use are
-   covered by this License.
-
-   b) Accompany the object code with a copy of the GNU GPL and this license
-   document.
-
-  4. Combined Works.
-
-  You may convey a Combined Work under terms of your choice that,
-taken together, effectively do not restrict modification of the
-portions of the Library contained in the Combined Work and reverse
-engineering for debugging such modifications, if you also do each of
-the following:
-
-   a) Give prominent notice with each copy of the Combined Work that
-   the Library is used in it and that the Library and its use are
-   covered by this License.
-
-   b) Accompany the Combined Work with a copy of the GNU GPL and this license
-   document.
-
-   c) For a Combined Work that displays copyright notices during
-   execution, include the copyright notice for the Library among
-   these notices, as well as a reference directing the user to the
-   copies of the GNU GPL and this license document.
-
-   d) Do one of the following:
-
-       0) Convey the Minimal Corresponding Source under the terms of this
-       License, and the Corresponding Application Code in a form
-       suitable for, and under terms that permit, the user to
-       recombine or relink the Application with a modified version of
-       the Linked Version to produce a modified Combined Work, in the
-       manner specified by section 6 of the GNU GPL for conveying
-       Corresponding Source.
-
-       1) Use a suitable shared library mechanism for linking with the
-       Library.  A suitable mechanism is one that (a) uses at run time
-       a copy of the Library already present on the user's computer
-       system, and (b) will operate properly with a modified version
-       of the Library that is interface-compatible with the Linked
-       Version.
-
-   e) Provide Installation Information, but only if you would otherwise
-   be required to provide such information under section 6 of the
-   GNU GPL, and only to the extent that such information is
-   necessary to install and execute a modified version of the
-   Combined Work produced by recombining or relinking the
-   Application with a modified version of the Linked Version. (If
-   you use option 4d0, the Installation Information must accompany
-   the Minimal Corresponding Source and Corresponding Application
-   Code. If you use option 4d1, you must provide the Installation
-   Information in the manner specified by section 6 of the GNU GPL
-   for conveying Corresponding Source.)
-
-  5. Combined Libraries.
-
-  You may place library facilities that are a work based on the
-Library side by side in a single library together with other library
-facilities that are not Applications and are not covered by this
-License, and convey such a combined library under terms of your
-choice, if you do both of the following:
-
-   a) Accompany the combined library with a copy of the same work based
-   on the Library, uncombined with any other library facilities,
-   conveyed under the terms of this License.
-
-   b) Give prominent notice with the combined library that part of it
-   is a work based on the Library, and explaining where to find the
-   accompanying uncombined form of the same work.
-
-  6. Revised Versions of the GNU Lesser General Public License.
-
-  The Free Software Foundation may publish revised and/or new versions
-of the GNU Lesser General Public License from time to time. Such new
-versions will be similar in spirit to the present version, but may
-differ in detail to address new problems or concerns.
-
-  Each version is given a distinguishing version number. If the
-Library as you received it specifies that a certain numbered version
-of the GNU Lesser General Public License "or any later version"
-applies to it, you have the option of following the terms and
-conditions either of that published version or of any later version
-published by the Free Software Foundation. If the Library as you
-received it does not specify a version number of the GNU Lesser
-General Public License, you may choose any version of the GNU Lesser
-General Public License ever published by the Free Software Foundation.
-
-  If the Library as you received it specifies that a proxy can decide
-whether future versions of the GNU Lesser General Public License shall
-apply, that proxy's public statement of acceptance of any version is
-permanent authorization for you to choose that version for the
-Library.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -1,7 +1,5 @@
-# Copyright (C) 2018 Fondazione Istituto Italiano di Tecnologia (IIT)
-# All Rights Reserved.
-# Authors: Mohamed Babiker Mohamed Elobaid <mohamed.elobaid@iit.it>
-#          Giulio Romualdi <giulio.romualdi@iit.it>
+# SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+# SPDX-License-Identifier: BSD-3-Clause
 
 # List the subdirectory
 # http://stackoverflow.com/questions/7787823/cmake-how-to-get-the-name-of-all-subdirectories-of-a-directory

--- a/cmake/AddClangFormatTarget.cmake
+++ b/cmake/AddClangFormatTarget.cmake
@@ -1,10 +1,5 @@
-# Copyright (C) 2018 Fondazione Istituto Italiano di Tecnologia
-#
-# Licensed under either the GNU Lesser General Public License v3.0 :
-# https://www.gnu.org/licenses/lgpl-3.0.html
-# or the GNU Lesser General Public License v2.1 :
-# https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
-# at your option.
+# SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+# SPDX-License-Identifier: BSD-3-Clause
 
 # Targets to run and check source code with clang-format
 # Inspired from https://gitlab.cern.ch/unige-fei4tel/proteus/commit/8d906a45801c03832531e243f41f5f5a83177de0

--- a/cmake/AddInstallRPATHSupport.cmake
+++ b/cmake/AddInstallRPATHSupport.cmake
@@ -72,19 +72,8 @@
 # Note: see https://gitlab.kitware.com/cmake/cmake/issues/16589 for further
 # details.
 
-#=======================================================================
-# Copyright 2014 Istituto Italiano di Tecnologia (IIT)
-# @author Francesco Romano <francesco.romano@iit.it>
-#
-# Distributed under the OSI-approved BSD License (the "License");
-# see accompanying file Copyright.txt for details.
-#
-# This software is distributed WITHOUT ANY WARRANTY; without even the
-# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-# See the License for more information.
-#=======================================================================
-# (To distribute this file outside of CMake, substitute the full
-# License text for the above reference.)
+# SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+# SPDX-License-Identifier: BSD-3-Clause
 
 include(CMakeParseArguments)
 

--- a/cmake/AddUninstallTarget.cmake
+++ b/cmake/AddUninstallTarget.cmake
@@ -11,20 +11,8 @@
 # custom target uninstall that will remove the files installed by your package
 # (using install_manifest.txt)
 
-#=============================================================================
-# Copyright 2008-2013 Kitware, Inc.
-# Copyright 2013 iCub Facility, Istituto Italiano di Tecnologia
-#   Authors: Daniele E. Domenichelli <daniele.domenichelli@iit.it>
-#
-# Distributed under the OSI-approved BSD License (the "License");
-# see accompanying file Copyright.txt for details.
-#
-# This software is distributed WITHOUT ANY WARRANTY; without even the
-# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-# See the License for more information.
-#=============================================================================
-# (To distribute this file outside of CMake, substitute the full
-#  License text for the above reference.)
+# SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+# SPDX-License-Identifier: BSD-3-Clause
 
 
 if(DEFINED __ADD_UNINSTALL_TARGET_INCLUDED)

--- a/cmake/FindCybSDK.cmake
+++ b/cmake/FindCybSDK.cmake
@@ -1,5 +1,5 @@
-# Copyright 2020 Istituto Italiano di Tecnologia (IIT)
-# @author Kourosh Darvish <kourosh.darvish@iit.it>
+# SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+# SPDX-License-Identifier: BSD-3-Clause
 
 # Finds the Cyberith SDK
 #

--- a/cmake/FindSRanipalSDK.cmake
+++ b/cmake/FindSRanipalSDK.cmake
@@ -1,4 +1,5 @@
-# Copyright 2021 Istituto Italiano di Tecnologia (IIT)
+# SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+# SPDX-License-Identifier: BSD-3-Clause
 
 set(SRanipal_SDK_DIR $ENV{SRanipal_SDK_DIR} CACHE PATH "Path to the SRanipal C SDK (i.e. the 01_C folder).")
 

--- a/cmake/WalkingTeleoperationFindDependencies.cmake
+++ b/cmake/WalkingTeleoperationFindDependencies.cmake
@@ -1,8 +1,5 @@
-# Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT)
-# All rights reserved.
-#
-# This software may be modified and distributed under the terms of the
-# BSD-3-Clause license. See the accompanying LICENSE file for details.
+# SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+# SPDX-License-Identifier: BSD-3-Clause
 
 # This module checks if all the dependencies are installed and if the
 # dependencies to build some parts of WALKING_TELEOPERATION are satisfied.

--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -1,6 +1,5 @@
-# Copyright (C) 2018 Fondazione Istituto Italiano di Tecnologia (IIT)
-# All Rights Reserved.
-# Authors: Giulio Romualdi <giulio.romualdi@iit.it>
+# SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+# SPDX-License-Identifier: BSD-3-Clause
 
 add_subdirectory(Utils)
 add_subdirectory(Oculus_module)

--- a/modules/FaceExpressions_module/CMakeLists.txt
+++ b/modules/FaceExpressions_module/CMakeLists.txt
@@ -1,5 +1,5 @@
-# Copyright (C) 2021 Fondazione Istituto Italiano di Tecnologia (IIT)
-# All Rights Reserved.
+# SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+# SPDX-License-Identifier: BSD-3-Clause
 
 set(EXE_TARGET_NAME FaceExpressionsRetargetingModule)
 

--- a/modules/FaceExpressions_module/include/FaceExpressionsRetargeting.hpp
+++ b/modules/FaceExpressions_module/include/FaceExpressionsRetargeting.hpp
@@ -1,10 +1,5 @@
-/**
- * @file FaceExpressionsRetargeting.hpp
- * @authors Stefano Dafarra <stefano.dafarra@iit.it>
- * @copyright 2021 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2021
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #ifndef FACE_EXPRESSIONS_RETARGETING_H
 #define FACE_EXPRESSIONS_RETARGETING_H

--- a/modules/FaceExpressions_module/src/FaceExpressionsRetargeting.cpp
+++ b/modules/FaceExpressions_module/src/FaceExpressionsRetargeting.cpp
@@ -1,10 +1,5 @@
-/**
- * @file FaceExpressionsRetargeting.cpp
- * @authors Stefano Dafarra <stefano.dafarra@iit.it>
- * @copyright 2021 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2021
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #include <FaceExpressionsRetargeting.hpp>
 #include <yarp/os/Vocab.h>

--- a/modules/FaceExpressions_module/src/main.cpp
+++ b/modules/FaceExpressions_module/src/main.cpp
@@ -1,10 +1,5 @@
-/**
- * @file main.cpp
- * @authors Stefano Dafarra <stefano.dafarra@iit.it>
- * @copyright 2021 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2021
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #include <FaceExpressionsRetargeting.hpp>
 #include <yarp/os/Network.h>

--- a/modules/HapticGlove_module/CMakeLists.txt
+++ b/modules/HapticGlove_module/CMakeLists.txt
@@ -1,6 +1,5 @@
-# Copyright (C) 2020 Fondazione Istituto Italiano di Tecnologia (IIT)
-# All Rights Reserved.
-# Authors: Kourosh Darvish <kourosh.darvish@iit.it>
+# SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+# SPDX-License-Identifier: BSD-3-Clause
 
 # set target name
 set(EXE_TARGET_NAME HapticGloveModule)

--- a/modules/HapticGlove_module/include/ControlHelper.hpp
+++ b/modules/HapticGlove_module/include/ControlHelper.hpp
@@ -1,10 +1,6 @@
-/**
- * @file ControlHelper.hpp
- * @authors Kourosh Darvish <kourosh.darvish@iit.it>
- * @copyright 2021 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2021
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
+
 #ifndef CONTROL_HELPER_HPP
 #define CONTROL_HELPER_HPP
 

--- a/modules/HapticGlove_module/include/GloveControlHelper.hpp
+++ b/modules/HapticGlove_module/include/GloveControlHelper.hpp
@@ -1,10 +1,5 @@
-/**
- * @file GloveControlHelper.hpp
- * @authors Kourosh Darvish <kourosh.darvish@iit.it>
- * @copyright 2021 Artificial and Mechanical Intelligence - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2021
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #ifndef GLOVE_CONTROL_HELPER_HPP
 #define GLOVE_CONTROL_HELPER_HPP

--- a/modules/HapticGlove_module/include/GloveWearable.hpp
+++ b/modules/HapticGlove_module/include/GloveWearable.hpp
@@ -1,10 +1,5 @@
-/**
- * @file GloveWearable.hpp
- * @authors  Kourosh Darvish <kourosh.darvish@iit.it>
- * @copyright 2021 Artificial and Mechanical Intelligence - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2021
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #ifndef GLOVE_WEARABLE_HPP
 #define GLOVE_WEARABLE_HPP

--- a/modules/HapticGlove_module/include/HapticGloveModule.hpp
+++ b/modules/HapticGlove_module/include/HapticGloveModule.hpp
@@ -1,10 +1,5 @@
-/**
- * @file HapticGloveModule.hpp
- * @authors Kourosh Darvish <kourosh.darvish@iit.it>
- * @copyright 2020 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2020
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #ifndef HAPTIC_GLOVE_MODULE_HPP
 #define HAPTIC_GLOVE_MODULE_HPP

--- a/modules/HapticGlove_module/include/KalmanFilter.hpp
+++ b/modules/HapticGlove_module/include/KalmanFilter.hpp
@@ -1,10 +1,5 @@
-/**
- * @file KalmanFilter.hpp
- * @authors  Kourosh Darvish <kourosh.darvish@iit.it>
- * @copyright 2020 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2020
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 /*
  * Implementation based on Book:

--- a/modules/HapticGlove_module/include/LinearRegression.hpp
+++ b/modules/HapticGlove_module/include/LinearRegression.hpp
@@ -1,10 +1,5 @@
-/**
- * @file LinearRegression.hpp
- * @authors  Kourosh Darvish <kourosh.darvish@iit.it>
- * @copyright 2021 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2021
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #ifndef LINEAR_REGRESSION_HPP
 #define LINEAR_REGRESSION_HPP

--- a/modules/HapticGlove_module/include/Logger.hpp
+++ b/modules/HapticGlove_module/include/Logger.hpp
@@ -1,10 +1,5 @@
-/**
- * @file Logger.hpp
- * @authors  Kourosh Darvish <kourosh.darvish@iit.it>
- * @copyright 2021 Artificial and Mechanical Intelligence - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2021
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #ifndef LOGGER_HPP
 #define LOGGER_HPP

--- a/modules/HapticGlove_module/include/MotorEstimation.hpp
+++ b/modules/HapticGlove_module/include/MotorEstimation.hpp
@@ -1,10 +1,5 @@
-/**
- * @file MotorEstimation.hpp
- * @authors  Kourosh Darvish <kourosh.darvish@iit.it>
- * @copyright 2020 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2020
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #ifndef MOTOR_ESTIMATION_HPP
 #define MOTOR_ESTIMATION_HPP

--- a/modules/HapticGlove_module/include/Retargeting.hpp
+++ b/modules/HapticGlove_module/include/Retargeting.hpp
@@ -1,10 +1,5 @@
-/**
- * @file Retargeting.hpp
- * @authors  Kourosh Darvish <kourosh.darvish@iit.it>
- * @copyright 2021 Artificial and Mechanical Intelligence - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2021
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #ifndef RETARGETING_HPP
 #define RETARGETING_HPP

--- a/modules/HapticGlove_module/include/RobotController.hpp
+++ b/modules/HapticGlove_module/include/RobotController.hpp
@@ -1,10 +1,5 @@
-/**
- * @file RobotController.hpp
- * @authors Kourosh Darvish <kourosh.darvish@iit.it>
- * @copyright 2020 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2020
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #ifndef ROBOT_CONTROLLER_HPP
 #define ROBOT_CONTROLLER_HPP

--- a/modules/HapticGlove_module/include/RobotInterface.hpp
+++ b/modules/HapticGlove_module/include/RobotInterface.hpp
@@ -1,10 +1,5 @@
-/**
- * @file RobotInterface.hpp
- * @authors Kourosh Darvish <kourosh.darvish@iit.it>
- * @copyright 2020 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2020
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #ifndef ROBOT_INTERFACE_HPP
 #define ROBOT_INTERFACE_HPP

--- a/modules/HapticGlove_module/include/RobotMotorsEstimation.hpp
+++ b/modules/HapticGlove_module/include/RobotMotorsEstimation.hpp
@@ -1,10 +1,5 @@
-/**
- * @file RobotMotorsEstimation.hpp
- * @authors  Kourosh Darvish <kourosh.darvish@iit.it>
- * @copyright 2020 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2020
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #ifndef ROBOT_MOTORS_ESTIMATION_HPP
 #define ROBOT_MOTORS_ESTIMATION_HPP

--- a/modules/HapticGlove_module/include/RobotSkin.hpp
+++ b/modules/HapticGlove_module/include/RobotSkin.hpp
@@ -1,10 +1,5 @@
-﻿/**
- * @file RobotSkin.hpp
- * @authors Kourosh Darvish <kourosh.darvish@iit.it>
- * @copyright 2021 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2021
- */
+﻿// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #ifndef ROBOT_SKIN_HPP
 #define ROBOT_SKIN_HPP

--- a/modules/HapticGlove_module/include/Teleoperation.hpp
+++ b/modules/HapticGlove_module/include/Teleoperation.hpp
@@ -1,10 +1,5 @@
-/**
- * @file Teleoperation.hpp
- * @authors  Kourosh Darvish <kourosh.darvish@iit.it>
- * @copyright 2021 Artificial and Mechanical Intelligence - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2021
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #ifndef TELEOPERATION_HPP
 #define TELEOPERATION_HPP

--- a/modules/HapticGlove_module/src/ControlHelper.cpp
+++ b/modules/HapticGlove_module/src/ControlHelper.cpp
@@ -1,4 +1,6 @@
-// teleoperation
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
+
 #include <ControlHelper.hpp>
 
 using namespace HapticGlove;

--- a/modules/HapticGlove_module/src/GloveControlHelper.cpp
+++ b/modules/HapticGlove_module/src/GloveControlHelper.cpp
@@ -1,10 +1,5 @@
-/**
- * @file GloveControlHelper.cpp
- * @authors Kourosh Darvish <kourosh.darvish@iit.it>
- * @copyright 2021 Artificial and Mechanical Intelligence - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2021
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #include <GloveControlHelper.hpp>
 #include <Utils.hpp>

--- a/modules/HapticGlove_module/src/GloveWearable.cpp
+++ b/modules/HapticGlove_module/src/GloveWearable.cpp
@@ -1,10 +1,5 @@
-/**
- * @file GloveWearable.cpp
- * @authors  Kourosh Darvish <kourosh.darvish@iit.it>
- * @copyright 2021 Artificial and Mechanical Intelligence - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2021
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #include <GloveWearable.hpp>
 #include <Utils.hpp>

--- a/modules/HapticGlove_module/src/HapticGloveModule.cpp
+++ b/modules/HapticGlove_module/src/HapticGloveModule.cpp
@@ -1,10 +1,5 @@
-/**
- * @file HapticGloveModule.cpp
- * @authors  Kourosh Darvish <kourosh.darvish@iit.it>
- * @copyright 2020 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2020
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 // std
 #include <thread>

--- a/modules/HapticGlove_module/src/KalmanFilter.cpp
+++ b/modules/HapticGlove_module/src/KalmanFilter.cpp
@@ -1,10 +1,5 @@
-/**
- * @file KalmanFilter.cpp
- * @authors  Kourosh Darvish <kourosh.darvish@iit.it>
- * @copyright 2020 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2020
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #include <KalmanFilter.hpp>
 #include <iostream>

--- a/modules/HapticGlove_module/src/LinearRegression.cpp
+++ b/modules/HapticGlove_module/src/LinearRegression.cpp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
+
 #include <LinearRegression.hpp>
 
 using namespace HapticGlove;

--- a/modules/HapticGlove_module/src/Logger.cpp
+++ b/modules/HapticGlove_module/src/Logger.cpp
@@ -1,10 +1,5 @@
-/**
- * @file Logger.cpp
- * @authors  Kourosh Darvish <kourosh.darvish@iit.it>
- * @copyright 2021 Artificial and Mechanical Intelligence - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2021
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 // teleoperation
 #include <Logger.hpp>

--- a/modules/HapticGlove_module/src/MotorEstimation.cpp
+++ b/modules/HapticGlove_module/src/MotorEstimation.cpp
@@ -1,10 +1,5 @@
-/**
- * @file MotorEstimation.cpp
- * @authors  Kourosh Darvish <kourosh.darvish@iit.it>
- * @copyright 2020 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2020
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #include <MotorEstimation.hpp>
 #include <iostream>

--- a/modules/HapticGlove_module/src/Retargeting.cpp
+++ b/modules/HapticGlove_module/src/Retargeting.cpp
@@ -1,10 +1,5 @@
-﻿/**
- * @file Retargeting.cpp
- * @authors  Kourosh Darvish <kourosh.darvish@iit.it>
- * @copyright 2021 Artificial and Mechanical Intelligence - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2021
- */
+﻿// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 // std
 #include <algorithm>

--- a/modules/HapticGlove_module/src/RobotController.cpp
+++ b/modules/HapticGlove_module/src/RobotController.cpp
@@ -1,10 +1,5 @@
-/**
- * @file RobotController.cpp
- * @authors Kourosh Darvish <kourosh.darvish@iit.it>
- * @copyright 2020 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2020
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 // teleoperation
 #include <RobotController.hpp>

--- a/modules/HapticGlove_module/src/RobotInterface.cpp
+++ b/modules/HapticGlove_module/src/RobotInterface.cpp
@@ -1,10 +1,5 @@
-/**
- * @file RobotInterface.cpp
- * @authors Kourosh Darvish <kourosh.darvish@iit.it>
- * @copyright 2020 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2020
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #include <algorithm>
 #include <iterator>

--- a/modules/HapticGlove_module/src/RobotMotorsEstimation.cpp
+++ b/modules/HapticGlove_module/src/RobotMotorsEstimation.cpp
@@ -1,10 +1,5 @@
-/**
- * @file RobotMotorsEstimation.cpp
- * @authors  Kourosh Darvish <kourosh.darvish@iit.it>
- * @copyright 2020 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2020
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #include <Utils.hpp>
 #include <yarp/os/LogStream.h>

--- a/modules/HapticGlove_module/src/RobotSkin.cpp
+++ b/modules/HapticGlove_module/src/RobotSkin.cpp
@@ -1,10 +1,5 @@
-/**
- * @file RobotSkin.cpp
- * @authors Kourosh Darvish <kourosh.darvish@iit.it>
- * @copyright 2021 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2021
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 // std
 #include <math.h>

--- a/modules/HapticGlove_module/src/Teleoperation.cpp
+++ b/modules/HapticGlove_module/src/Teleoperation.cpp
@@ -1,10 +1,5 @@
-﻿/**
- * @file Teleoperation.cpp
- * @authors  Kourosh Darvish <kourosh.darvish@iit.it>
- * @copyright 2021 Artificial and Mechanical Intelligence - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2021
- */
+﻿// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #include <Logger.hpp>
 #include <Teleoperation.hpp>

--- a/modules/HapticGlove_module/src/main.cpp
+++ b/modules/HapticGlove_module/src/main.cpp
@@ -1,10 +1,5 @@
-/**
- * @file main.cpp
- * @authors Kourosh Darvish <kourosh.darvish@iit.it>
- * @copyright 2020 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2020
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 // YARP
 #include <yarp/os/LogStream.h>

--- a/modules/HapticGlove_module/thrift/HapticGloveTeleoperationService.thrift
+++ b/modules/HapticGlove_module/thrift/HapticGloveTeleoperationService.thrift
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 /**
  * Definition of the HapticGlove teleoperation RPC service

--- a/modules/HapticGlove_module/thrift/RobotSkinService.thrift
+++ b/modules/HapticGlove_module/thrift/RobotSkinService.thrift
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 /**
  * Definition of the RobotSkin RPC service

--- a/modules/Oculus_module/CMakeLists.txt
+++ b/modules/Oculus_module/CMakeLists.txt
@@ -1,6 +1,5 @@
-# Copyright (C) 2018 Fondazione Istituto Italiano di Tecnologia (IIT)
-# All Rights Reserved.
-# Authors: Giulio Romualdi <giulio.romualdi@iit.it>
+# SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+# SPDX-License-Identifier: BSD-3-Clause
 
 # set target name
 set(EXE_TARGET_NAME OculusRetargetingModule)

--- a/modules/Oculus_module/include/FingersRetargeting.hpp
+++ b/modules/Oculus_module/include/FingersRetargeting.hpp
@@ -1,11 +1,5 @@
-/**
- * @file FingersRetargeting.hpp
- * @authors Giulio Romualdi <giulio.romualdi@iit.it>
- *          Mohamed Babiker Mohamed Elobaid <mohamed.elobaid@iit.it>
- * @copyright 2018 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2018
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #ifndef FINGERS_RETARGETING_HPP
 #define FINGERS_RETARGETING_HPP

--- a/modules/Oculus_module/include/HandRetargeting.hpp
+++ b/modules/Oculus_module/include/HandRetargeting.hpp
@@ -1,11 +1,5 @@
-/**
- * @file HandRetargeting.hpp
- * @authors Giulio Romualdi <giulio.romualdi@iit.it>
- *          Mohamed Babiker Mohamed Elobaid <mohamed.elobaid@iit.it>
- * @copyright 2018 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2018
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #ifndef HAND_RETARGETING_HPP
 #define HAND_RETARGETING_HPP

--- a/modules/Oculus_module/include/HeadRetargeting.hpp
+++ b/modules/Oculus_module/include/HeadRetargeting.hpp
@@ -1,11 +1,5 @@
-/**
- * @file HeadRetargeting.hpp
- * @authors Giulio Romualdi <giulio.romualdi@iit.it>
- *          Mohamed Babiker Mohamed Elobaid <mohamed.elobaid@iit.it>
- * @copyright 2018 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2018
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #ifndef HEAD_RETARGETING_HPP
 #define HEAD_RETARGETING_HPP

--- a/modules/Oculus_module/include/OculusModule.hpp
+++ b/modules/Oculus_module/include/OculusModule.hpp
@@ -1,11 +1,5 @@
-/**
- * @file OculusModule.hpp
- * @authors Giulio Romualdi <giulio.romualdi@iit.it>
- *          Mohamed Babiker Mohamed Elobaid <mohamed.elobaid@iit.it>
- * @copyright 2018 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2018
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #ifndef OCULUS_MODULE_HPP
 #define OCULUS_MODULE_HPP

--- a/modules/Oculus_module/include/RetargetingController.hpp
+++ b/modules/Oculus_module/include/RetargetingController.hpp
@@ -1,10 +1,5 @@
-/**
- * @file RetargetingController.hpp
- * @authors Giulio Romualdi <giulio.romualdi@iit.it>
- * @copyright 2018 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2018
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #ifndef RETARGETING_CONTROLLER_HPP
 #define RETARGETING_CONTROLLER_HPP

--- a/modules/Oculus_module/include/RobotControlHelper.hpp
+++ b/modules/Oculus_module/include/RobotControlHelper.hpp
@@ -1,10 +1,5 @@
-/**
- * @file RobotControlHelper.hpp
- * @authors Giulio Romualdi <giulio.romualdi@iit.it>
- * @copyright 2018 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2018
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #ifndef ROBOT_CONTROL_HELPER_HPP
 #define ROBOT_CONTROL_HELPER_HPP

--- a/modules/Oculus_module/src/FingersRetargeting.cpp
+++ b/modules/Oculus_module/src/FingersRetargeting.cpp
@@ -1,11 +1,5 @@
-/**
- * @file FingersRetargeting.cpp
- * @authors Giulio Romualdi <giulio.romualdi@iit.it>
- *          Mohamed Babiker Mohamed Elobaid <mohamed.elobaid@iit.it>
- * @copyright 2018 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2018
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #include <FingersRetargeting.hpp>
 #include <Utils.hpp>

--- a/modules/Oculus_module/src/HandRetargeting.cpp
+++ b/modules/Oculus_module/src/HandRetargeting.cpp
@@ -1,11 +1,5 @@
-/**
- * @file HandRetargeting.cpp
- * @authors Giulio Romualdi <giulio.romualdi@iit.it>
- *          Mohamed Babiker Mohamed Elobaid <mohamed.elobaid@iit.it>
- * @copyright 2018 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2018
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 // iDynTree
 #include <iDynTree/Core/EigenHelpers.h>

--- a/modules/Oculus_module/src/HeadRetargeting.cpp
+++ b/modules/Oculus_module/src/HeadRetargeting.cpp
@@ -1,11 +1,5 @@
-/**
- * @file HeadRetargeting.cpp
- * @authors Giulio Romualdi <giulio.romualdi@iit.it>
- *          Mohamed Babiker Mohamed Elobaid <mohamed.elobaid@iit.it>
- * @copyright 2018 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2018
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 // iDynTree
 #include <iDynTree/Core/EigenHelpers.h>

--- a/modules/Oculus_module/src/OculusModule.cpp
+++ b/modules/Oculus_module/src/OculusModule.cpp
@@ -1,11 +1,5 @@
-/**
- * @file OculusModule.cpp
- * @authors  Mohamed Babiker Mohamed Elobaid <mohamed.elobaid@iit.it>
- *           Giulio Romualdi <giulio.romualdi@iit.it>
- * @copyright 2018 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2018
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 // YARP
 #include <yarp/dev/FrameGrabberInterfaces.h>

--- a/modules/Oculus_module/src/RetargetingController.cpp
+++ b/modules/Oculus_module/src/RetargetingController.cpp
@@ -1,10 +1,5 @@
-/**
- * @file RetargetingController.cpp
- * @authors Giulio Romualdi <giulio.romualdi@iit.it>
- * @copyright 2018 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2018
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #include <RetargetingController.hpp>
 

--- a/modules/Oculus_module/src/RobotControlHelper.cpp
+++ b/modules/Oculus_module/src/RobotControlHelper.cpp
@@ -1,10 +1,5 @@
-/**
- * @file RobotControlHelper.cpp
- * @authors Giulio Romualdi <giulio.romualdi@iit.it>
- * @copyright 2018 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2018
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #include <limits>
 

--- a/modules/Oculus_module/src/main.cpp
+++ b/modules/Oculus_module/src/main.cpp
@@ -1,10 +1,5 @@
-/**
- * @file main.cpp
- * @authors Giulio Romualdi <giulio.romualdi@iit.it>
- * @copyright 2018 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2018
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 // YARP
 #include <yarp/os/LogStream.h>

--- a/modules/Oculus_module/thrifts/TeleoperationCommands.thrift
+++ b/modules/Oculus_module/thrifts/TeleoperationCommands.thrift
@@ -1,10 +1,5 @@
-/**
- * @file TeleoperationCommands.thrift
- * @authors Kourosh Darvish <kourosh.darvish@iit.it>
- * @copyright 2021 Artificial and Mechanical Intelligence Lab - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2021
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 service TeleoperationCommands
 {

--- a/modules/SRanipal_module/CMakeLists.txt
+++ b/modules/SRanipal_module/CMakeLists.txt
@@ -1,5 +1,5 @@
-# Copyright (C) 2021 Fondazione Istituto Italiano di Tecnologia (IIT)
-# All Rights Reserved.
+# SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+# SPDX-License-Identifier: BSD-3-Clause
 
 if (NOT WIN32)
     message(FATAL_ERROR "The SRanipalModule is available only on Windows")

--- a/modules/SRanipal_module/include/AdvancedJoypad.hpp
+++ b/modules/SRanipal_module/include/AdvancedJoypad.hpp
@@ -1,10 +1,5 @@
-/**
- * @file AdvancedJoypad.hpp
- * @authors Stefano Dafarra <stefano.dafarra@iit.it>
- * @copyright 2021 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2022
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #ifndef ADVANCEDJOYPAD_HPP
 #define ADVANCEDJOYPAD_HPP

--- a/modules/SRanipal_module/include/EyelidsRetargeting.hpp
+++ b/modules/SRanipal_module/include/EyelidsRetargeting.hpp
@@ -1,10 +1,5 @@
-/**
- * @file EyelidsRetargeting.hpp
- * @authors Stefano Dafarra <stefano.dafarra@iit.it>
- * @copyright 2021 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2021
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #ifndef EYELIDSRETARGETING_HPP
 #define EYELIDSRETARGETING_HPP

--- a/modules/SRanipal_module/include/FaceExpressionsRetargeting.hpp
+++ b/modules/SRanipal_module/include/FaceExpressionsRetargeting.hpp
@@ -1,10 +1,5 @@
-/**
- * @file FaceExpressionsRetargeting.hpp
- * @authors Stefano Dafarra <stefano.dafarra@iit.it>
- * @copyright 2021 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2021
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #ifndef FACEEXPRESSIONSRETARGETING_HPP
 #define FACEEXPRESSIONSRETARGETING_HPP

--- a/modules/SRanipal_module/include/GazeRetargeting.hpp
+++ b/modules/SRanipal_module/include/GazeRetargeting.hpp
@@ -1,10 +1,5 @@
-/**
- * @file GazeRetargeting.hpp
- * @authors Stefano Dafarra <stefano.dafarra@iit.it>
- * @copyright 2021 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2021
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #ifndef GAZERETARGETING_HPP
 #define GAZERETARGETING_HPP

--- a/modules/SRanipal_module/include/SRanipalInterface.hpp
+++ b/modules/SRanipal_module/include/SRanipalInterface.hpp
@@ -1,10 +1,5 @@
-/**
- * @file SRanipalInterface.hpp
- * @authors Stefano Dafarra <stefano.dafarra@iit.it>
- * @copyright 2021 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2021
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 
 #ifndef SRANIPALINTERFACE_HPP

--- a/modules/SRanipal_module/include/SRanipalModule.hpp
+++ b/modules/SRanipal_module/include/SRanipalModule.hpp
@@ -1,10 +1,5 @@
-/**
- * @file SRanipalModule.hpp
- * @authors Stefano Dafarra <stefano.dafarra@iit.it>
- * @copyright 2021 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2021
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #ifndef SRANIPALMODULE_HPP
 #define SRANIPALMODULE_HPP

--- a/modules/SRanipal_module/include/VRInterface.hpp
+++ b/modules/SRanipal_module/include/VRInterface.hpp
@@ -1,10 +1,6 @@
-/**
- * @file VRInterface.hpp
- * @authors Stefano Dafarra <stefano.dafarra@iit.it>
- * @copyright 2021 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2022
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
+
 #ifndef VRINTERFACE_HPP
 #define VRINTERFACE_HPP
 

--- a/modules/SRanipal_module/src/AdvancedJoypad.cpp
+++ b/modules/SRanipal_module/src/AdvancedJoypad.cpp
@@ -1,10 +1,5 @@
-/**
- * @file AdvancedJoypad.hpp
- * @authors Stefano Dafarra <stefano.dafarra@iit.it>
- * @copyright 2021 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2022
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #include <AdvancedJoypad.hpp>
 #include <yarp/os/LogStream.h>

--- a/modules/SRanipal_module/src/EyelidsRetargeting.cpp
+++ b/modules/SRanipal_module/src/EyelidsRetargeting.cpp
@@ -1,10 +1,5 @@
-/**
-     * @file EyelidsRetargeting.cpp
-     * @authors Stefano Dafarra <stefano.dafarra@iit.it>
-     * @copyright 2021 iCub Facility - Istituto Italiano di Tecnologia
-     *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
-     * @date 2021
-     */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 
 #include <EyelidsRetargeting.hpp>

--- a/modules/SRanipal_module/src/FaceExpressionsRetargeting.cpp
+++ b/modules/SRanipal_module/src/FaceExpressionsRetargeting.cpp
@@ -1,10 +1,5 @@
-/**
- * @file FaceExpressionsRetargeting.cpp
- * @authors Stefano Dafarra <stefano.dafarra@iit.it>
- * @copyright 2021 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2021
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #include <FaceExpressionsRetargeting.hpp>
 #include <yarp/os/LogStream.h>

--- a/modules/SRanipal_module/src/GazeRetargeting.cpp
+++ b/modules/SRanipal_module/src/GazeRetargeting.cpp
@@ -1,10 +1,5 @@
-/**
- * @file GazeRetargeting.cpp
- * @authors Stefano Dafarra <stefano.dafarra@iit.it>
- * @copyright 2021 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2021
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #include <GazeRetargeting.hpp>
 #include <yarp/os/LogStream.h>

--- a/modules/SRanipal_module/src/SRanipalInterface.cpp
+++ b/modules/SRanipal_module/src/SRanipalInterface.cpp
@@ -1,10 +1,5 @@
-/**
- * @file SRanipalInterface.cpp
- * @authors Stefano Dafarra <stefano.dafarra@iit.it>
- * @copyright 2021 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2021
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #include <SRanipalInterface.hpp>
 #include <yarp/os/LogStream.h>

--- a/modules/SRanipal_module/src/SRanipalModule.cpp
+++ b/modules/SRanipal_module/src/SRanipalModule.cpp
@@ -1,10 +1,5 @@
-/**
- * @file SRanipalModule.cpp
- * @authors Stefano Dafarra <stefano.dafarra@iit.it>
- * @copyright 2021 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2021
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #include <SRanipalModule.hpp>
 #include <string>

--- a/modules/SRanipal_module/src/VRInterface.cpp
+++ b/modules/SRanipal_module/src/VRInterface.cpp
@@ -1,11 +1,5 @@
-/**
- * @file VRInterface.cpp
- * @authors Stefano Dafarra <stefano.dafarra@iit.it>
- * @copyright 2021 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2022
- */
-
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 #ifndef _USE_MATH_DEFINES //for using M_PI
 #define _USE_MATH_DEFINES
 #endif

--- a/modules/SRanipal_module/src/main.cpp
+++ b/modules/SRanipal_module/src/main.cpp
@@ -1,10 +1,5 @@
-/**
- * @file main.cpp
- * @authors Stefano Dafarra <stefano.dafarra@iit.it>
- * @copyright 2021 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2021
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #include <SRanipalModule.hpp>
 #include <yarp/os/Network.h>

--- a/modules/Utils/CMakeLists.txt
+++ b/modules/Utils/CMakeLists.txt
@@ -1,6 +1,5 @@
-# Copyright (C) 2018 Fondazione Istituto Italiano di Tecnologia (IIT)
-# All Rights Reserved.
-# Authors: Giulio Romualdi <giulio.romualdi@iit.it>
+# SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+# SPDX-License-Identifier: BSD-3-Clause
 
 # set target name
 set(UTILITY_LIBRARY_NAME UtilityLibrary)

--- a/modules/Utils/include/Utils.hpp
+++ b/modules/Utils/include/Utils.hpp
@@ -1,10 +1,5 @@
-/**
- * @file Utils.hpp
- * @authors Giulio Romualdi <giulio.romualdi@iit.it>
- * @copyright 2018 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2018
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #ifndef WALKING_UTILS_HPP
 #define WALKING_UTILS_HPP

--- a/modules/Utils/include/Utils.tpp
+++ b/modules/Utils/include/Utils.tpp
@@ -1,10 +1,5 @@
-/**
- * @file Utils.tpp
- * @authors Giulio Romualdi <giulio.romualdi@iit.it>
- * @copyright 2018 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2018
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 // std
 #include <iostream>

--- a/modules/Utils/src/Utils.cpp
+++ b/modules/Utils/src/Utils.cpp
@@ -1,10 +1,5 @@
-/**
- * @file Utils.cpp
- * @authors Giulio Romualdi <giulio.romualdi@iit.it>
- * @copyright 2018 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2018
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 // std
 #define _USE_MATH_DEFINES

--- a/modules/Virtualizer_module/CMakeLists.txt
+++ b/modules/Virtualizer_module/CMakeLists.txt
@@ -1,9 +1,5 @@
-# Copyright (C) 2018 Fondazione Istituto Italiano di Tecnologia (IIT)
-# All Rights Reserved.
-# Authors: Mohamed Babiker Mohamed Elobaid <mohamed.elobaid@iit.it>
-#          Giulio Romualdi <giulio.romualdi@iit.it>
-#
-# set target name
+# SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+# SPDX-License-Identifier: BSD-3-Clause
 
 set(EXE_TARGET_NAME VirtualizerModule)
 

--- a/modules/Virtualizer_module/include/VirtualizerModule.hpp
+++ b/modules/Virtualizer_module/include/VirtualizerModule.hpp
@@ -1,11 +1,5 @@
-/**
- * @file VirtualizerModule.hpp
- * @authors Giulio Romualdi <giulio.romualdi@iit.it>
- *          Mohamed Babiker Mohamed Elobaid <mohamed.elobaid@iit.it>
- * @copyright 2018 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2018
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #ifndef RETARGETING_VIRTUALIZER_MODULE_HPP
 #define RETARGETING_VIRTUALIZER_MODULE_HPP

--- a/modules/Virtualizer_module/src/VirtualizerModule.cpp
+++ b/modules/Virtualizer_module/src/VirtualizerModule.cpp
@@ -1,11 +1,5 @@
-/**
- * @file VirtualizerModule.cpp
- * @authors  Mohamed Babiker Mohamed Elobaid <mohamed.elobaid@iit.it>
- *           Giulio Romualdi <giulio.romualdi@iit.it>
- * @copyright 2018 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2018
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #define _USE_MATH_DEFINES
 #include <cmath>

--- a/modules/Virtualizer_module/src/main.cpp
+++ b/modules/Virtualizer_module/src/main.cpp
@@ -1,10 +1,5 @@
-/**
- * @file main.cpp
- * @authors Giulio Romualdi <giulio.romualdi@iit.it>
- * @copyright 2018 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2018
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 // YARP
 #include <yarp/os/LogStream.h>

--- a/modules/Virtualizer_module/thrift/virtualizerCommand.thrift
+++ b/modules/Virtualizer_module/thrift/virtualizerCommand.thrift
@@ -1,10 +1,5 @@
-/**
- * @file virtualizerCommands.thrift
- * @authors Giulio Romualdi <giulio.romualdi@iit.it>
- * @copyright 2019 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2018
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 service VirtualizerCommands
 {

--- a/modules/Xsens_module/CMakeLists.txt
+++ b/modules/Xsens_module/CMakeLists.txt
@@ -1,6 +1,5 @@
-# Copyright (C) 2018 Fondazione Istituto Italiano di Tecnologia (IIT)
-# All Rights Reserved.
-# Authors: Giulio Romualdi <giulio.romualdi@iit.it>
+# SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+# SPDX-License-Identifier: BSD-3-Clause
 
 # set target name
 set(EXE_TARGET_NAME XsensRetargetingModule)

--- a/modules/Xsens_module/include/XsensRetargeting.hpp
+++ b/modules/Xsens_module/include/XsensRetargeting.hpp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
+
 #ifndef XSENSRETARGETING_H
 #define XSENSRETARGETING_H
 

--- a/modules/Xsens_module/src/XsensRetargeting.cpp
+++ b/modules/Xsens_module/src/XsensRetargeting.cpp
@@ -1,4 +1,6 @@
-//#include "yarp/ HumanState.h"
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
+
 #include <Utils.hpp>
 #include <XsensRetargeting.hpp>
 #include <iterator>

--- a/modules/Xsens_module/src/main.cpp
+++ b/modules/Xsens_module/src/main.cpp
@@ -1,10 +1,5 @@
-/**
- * @file main.cpp
- * @authors Giulio Romualdi <giulio.romualdi@iit.it>
- * @copyright 2018 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2018
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 // YARP
 #include <XsensRetargeting.hpp>


### PR DESCRIPTION
License the repo under the BSD-3-Clause license. I also took the occasion to change license headers to SPDX-style tags (see https://spdx.github.io/spdx-spec/v2.3/file-tags/), that are more manageable and machine readable. 

As a result of the cleanup I deleted the authors name from the headers as it is more mantainable to just store this information in git, if there is any problem in this we can re-introduce them with a follow-up PR, using the `SPDX-FileContributor:` tag.