### PR TITLE
updated name of the YARP port from HDE

### DIFF
--- a/app/scripts/Faire-UserRetargeting-iFeel.xml
+++ b/app/scripts/Faire-UserRetargeting-iFeel.xml
@@ -57,8 +57,8 @@
     <node>icub-console</node>
     <tag>RobotStateProvider</tag>
     <dependencies>
-      <port timeout="15.0">/iCub/RobotStateWrapper/state:o</port>
-      <port timeout="15.0">/HDE/WearableTargetsWrapper/state:o</port>
+      <port timeout="15.0">/iCub/RobotStateServer/state:o</port>
+      <port timeout="15.0">/HDE/WearableTargetsServer/state:o</port>
     </dependencies>
   </module>
 

--- a/app/scripts/Faire-UserRetargeting.xml
+++ b/app/scripts/Faire-UserRetargeting.xml
@@ -48,8 +48,8 @@
     <node>icub-console</node>
     <tag>RobotStateProvider</tag>
     <dependencies>
-      <port timeout="15.0">/iCub/RobotStateWrapper/state:o</port>
-      <port timeout="15.0">/HDE/WearableTargetsWrapper/state:o</port>
+      <port timeout="15.0">/iCub/RobotStateServer/state:o</port>
+      <port timeout="15.0">/HDE/WearableTargetsServer/state:o</port>
     </dependencies>
   </module>
 

--- a/app/scripts/WalkingTeleoperationDumper.xml
+++ b/app/scripts/WalkingTeleoperationDumper.xml
@@ -190,7 +190,7 @@
   </connection>
   
   	<connection>
-        <from>/iCub/RobotStateWrapper/state:o</from>
+        <from>/iCub/RobotStateServer/state:o</from>
         <to>/icub_dump/robotState</to>
         <protocol>udp</protocol>
   </connection>

--- a/app/scripts/ergoCub-Teleoperation-3.xml
+++ b/app/scripts/ergoCub-Teleoperation-3.xml
@@ -37,8 +37,8 @@
     <node>localhost</node>
     <tag>RobotStateProvider</tag>
     <dependencies>
-      <port timeout="15.0">/ergoCub/RobotStateWrapper/state:o</port>
-      <port timeout="15.0">/HDE/WearableTargetsWrapper/state:o</port>
+      <port timeout="15.0">/ergoCub/RobotStateServer/state:o</port>
+      <port timeout="15.0">/HDE/WearableTargetsServer/state:o</port>
     </dependencies>
   </module>
 

--- a/app/scripts/ergoCub-Teleoperation-4.xml
+++ b/app/scripts/ergoCub-Teleoperation-4.xml
@@ -68,7 +68,7 @@
   </connection>
 
   <connection>
-    <from>/ergoCub/RobotStateWrapper/state:o</from>
+    <from>/ergoCub/RobotStateServer/state:o</from>
     <to>/walking-coordinator/humanState:i</to>
     <protocol>fast_tcp</protocol>
   </connection>


### PR DESCRIPTION
After having merged https://github.com/robotology/human-dynamics-estimation/pull/367 it will be necessary to merge also this PR in order to use the `yarpmanager` applications since the name of the YARP ports exposed by the devices in HDE are changed.