### PR TITLE
Fix compatibility with YARP 3.10 by adding missing header

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 3.5)
 set(CMAKE_CXX_STANDARD 14)
 
 project(walking-teleoperation
-  VERSION 1.3.6)
+  VERSION 1.3.7)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 include(WalkingTeleoperationFindDependencies)

--- a/modules/OpenXRJoypad_module/src/OpenXRJoypadModule.cpp
+++ b/modules/OpenXRJoypad_module/src/OpenXRJoypadModule.cpp
@@ -26,6 +26,7 @@
 #include <yarp/os/RpcClient.h>
 #include <yarp/os/Stamp.h>
 #include <yarp/sig/Matrix.h>
+#include <yarp/conf/version.h>
 
 #include <iDynTree/EigenHelpers.h>
 #include <iDynTree/YARPConversions.h>


### PR DESCRIPTION
Due to a missing header, https://github.com/robotology/walking-teleoperation/pull/153 fixed compatibility with YARP 3.11. but broke YARP 3.10 . Including the correct header make sure that the project is able to build with both YARP 3.10 and 3.11 .