### PR TITLE
Remove inclusion of deprecated yarp header FrameGrabberInterfaces.h

### DIFF
--- a/modules/Oculus_module/src/OculusModule.cpp
+++ b/modules/Oculus_module/src/OculusModule.cpp
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 // YARP
-#include <yarp/dev/FrameGrabberInterfaces.h>
+#include <yarp/dev/IFrameGrabberControlsDC1394.h>
+#include <yarp/dev/IFrameGrabberControls.h>
 #include <yarp/os/Bottle.h>
 #include <yarp/os/LogStream.h>
 #include <yarp/os/Property.h>


### PR DESCRIPTION
Similar to:
* https://github.com/robotology/gazebo-yarp-plugins/pull/698
* https://github.com/ami-iit/bipedal-locomotion-framework/pull/970


Part of https://github.com/robotology/robotology-superbuild/issues/1854 .