### PR TITLE
Add support for compiling shared library on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,15 @@
 # SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
 # SPDX-License-Identifier: BSD-3-Clause
 
-cmake_minimum_required(VERSION 3.5)
-set(CMAKE_CXX_STANDARD 14)
+cmake_minimum_required(VERSION 3.10)
 
 project(walking-teleoperation
-  VERSION 1.3.7)
+  VERSION 1.3.8)
+
+# To build shared libraries in Windows, we set CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS to TRUE.
+# See https://cmake.org/cmake/help/v3.4/variable/CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS.html
+# See https://blog.kitware.com/create-dlls-on-windows-without-declspec-using-new-cmake-export-all-feature/
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 include(WalkingTeleoperationFindDependencies)


### PR DESCRIPTION
Furthermore:
* Bump version to 1.3.8
* Remove hardcoding C++ version to C++14 as all modern compilers default to c++17
* Bump minimum CMake version to 3.10 to avoid warnings in CMake 4


Fix https://github.com/robotology/walking-teleoperation/issues/39
Fix https://github.com/robotology/robotology-superbuild/issues/1857